### PR TITLE
fix: correct core agent count and install.sh reliability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "sehoon787"
   },
   "metadata": {
-    "description": "All-in-one multi-agent orchestration for Claude Code — 53 core agents always loaded + 133 domain agent-packs on demand, 156 skills, 65 rules, 6 hooks, 3 MCP servers. Bundles agency-agents, everything-claude-code, and oh-my-claudecode with weekly CI auto-sync."
+    "description": "All-in-one multi-agent orchestration for Claude Code — 52 core agents always loaded + 133 domain agent-packs on demand, 156 skills, 65 rules, 6 hooks, 3 MCP servers. Bundles agency-agents, everything-claude-code, and oh-my-claudecode with weekly CI auto-sync."
   },
   "plugins": [
     {
       "name": "my-claude",
       "source": "./",
-      "description": "53 core agents always loaded + 133 domain agent-packs on demand (Boss orchestrator, Hephaestus autonomous worker, agency specialists, OMC agents), 156 skills, 65 rules, behavioral correction hooks, and MCP servers (Context7, Exa, grep.app)",
+      "description": "52 core agents always loaded + 133 domain agent-packs on demand (Boss orchestrator, Hephaestus autonomous worker, agency specialists, OMC agents), 156 skills, 65 rules, behavioral correction hooks, and MCP servers (Context7, Exa, grep.app)",
       "author": {
         "name": "sehoon787"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "my-claude",
-  "description": "All-in-one multi-agent orchestration plugin — 53 core agents + 133 domain agent-packs, 156 skills, behavioral hooks, and MCP servers bundled from 3 MIT upstream sources with weekly CI auto-sync",
+  "description": "All-in-one multi-agent orchestration plugin — 52 core agents + 133 domain agent-packs, 156 skills, behavioral hooks, and MCP servers bundled from 3 MIT upstream sources with weekly CI auto-sync",
   "version": "0.19.0",
   "author": {
     "name": "sehoon787"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -129,7 +129,7 @@ jobs:
       # ── 5. Update documentation counts ──
       - name: Update documentation counts
         run: |
-          CORE_AGENTS=$(find agents/core -name '*.md' | wc -l)
+          CORE_AGENTS=$(find agents/core -name '*.md' ! -name 'agent-teams-reference.md' | wc -l)
           OMO_AGENTS=$(find agents/omo -name '*.md' | wc -l)
           ENGINEERING_COUNT=$(find agents/agency/engineering -name '*.md' | wc -l)
           STRATEGY_COUNT=$(find agents/agency/strategy -name '*.md' | wc -l)

--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -1,7 +1,7 @@
 # my-claude AI Installation Guide
 
 You are an AI agent setting up a Claude Code multi-agent orchestration environment.
-The plugin bundles 186 agents (53 core + 133 domain agent-packs), 156 skills, 65 rules, 6 hooks, and 3 MCP servers.
+The plugin bundles 185 agents (52 core + 133 domain agent-packs), 156 skills, 65 rules, 6 hooks, and 3 MCP servers.
 Only 2-3 steps are needed.
 
 ---
@@ -22,7 +22,7 @@ node -e "const fs=require('fs'),p=require('path'),f=p.join(require('os').homedir
 ```
 
 This installs:
-- 53 core agents in ~/.claude/agents/ (always loaded): Boss, 9 OMO, 19 OMC, 23 engineering
+- 52 core agents in ~/.claude/agents/ (always loaded): Boss, 9 OMO, 19 OMC, 23 engineering
 - 133 domain agent-packs in ~/.claude/agent-packs/ (on-demand via symlink)
 - 156 skills (125 ECC + 31 OMC)
 - 65 rules
@@ -66,7 +66,7 @@ After manual install, set Boss as default agent:
 
 ```bash
 # Set Boss as default agent (one-time setup)
-node -e "const fs=require('fs'),p=require('path'),f=p.join(require('os').homedir(),'.claude','settings.json');const s=fs.existsSync(f)?JSON.parse(fs.readFileSync(f,'utf8')):{};s.env={...s.env,CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:'1'};s.agent=s.agent||'boss';fs.writeFileSync(f,JSON.stringify(s,null,2))"
+node -e "const fs=require('fs'),p=require('path'),f=p.join(require('os').homedir(),'.claude','settings.json');const s=fs.existsSync(f)?JSON.parse(fs.readFileSync(f,'utf8')):{};s.env={...s.env,CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:'1'};s.agent=s.agent||'boss';s.mcpServers={...s.mcpServers,context7:{type:'url',url:'https://mcp.context7.com/mcp'},exa:{type:'url',url:'https://mcp.exa.ai/mcp?tools=web_search_exa'},grep_app:{type:'url',url:'https://mcp.grep.app'}};fs.writeFileSync(f,JSON.stringify(s,null,2))"
 ```
 
 Note: Manual install does not configure hooks. Run the node command above to set Boss as default agent. See SETUP.md Section 7 Option D for hooks setup.
@@ -131,7 +131,7 @@ echo "omo:              $(command -v oh-my-opencode >/dev/null 2>&1 && echo 'OK'
 ```
 
 Expected:
-- Core agents: 53+
+- Core agents: 52+ (agent-teams-reference is in docs/nexus, not counted)
 - Agent packs: 133+
 - Plugin skills: 156+
 - Rules: 65

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 All-in-one Claude Code multi-agent orchestration plugin — install once, get everything.
 
-Bundles **186 agents**, **156 skills**, **65 rules**, **6 hooks**, and **3 MCP servers** from 3 MIT upstream sources into a single plugin. The **Boss** dynamic meta-orchestrator auto-discovers all installed components at runtime and routes tasks to the optimal specialist. GitHub Actions CI syncs upstream changes weekly.
+Bundles **185 agents**, **156 skills**, **65 rules**, **6 hooks**, and **3 MCP servers** from 3 MIT upstream sources into a single plugin. The **Boss** dynamic meta-orchestrator auto-discovers all installed components at runtime and routes tasks to the optimal specialist. GitHub Actions CI syncs upstream changes weekly.
 
 <p align="center">
   <img src="./assets/demo.svg" alt="my-claude demo" width="700">
@@ -116,7 +116,7 @@ Read the full output and execute each step in order. Use `curl`, not `WebFetch`.
 - **grep.app**: GitHub open-source code search
 
 ### All-in-One Bundle
-- Plugin install provides **186 agents, 156 skills, and 65 rules** instantly
+- Plugin install provides **185 agents, 156 skills, and 65 rules** instantly
 - Bundles 3 MIT upstream sources (agency-agents, everything-claude-code, oh-my-claudecode)
 - Weekly CI auto-sync keeps bundled content up-to-date with upstream
 - Companion `install.sh` adds npm tools and proprietary Anthropic skills
@@ -125,7 +125,7 @@ Read the full output and execute each step in order. Use `curl`, not `WebFetch`.
 
 ## Core + OMO Agents
 
-**Boss** is the only my-claude original agent. The remaining 9 are [OMO agents](https://github.com/code-yeongyu/oh-my-openagent) that Boss uses as sub-orchestrators and specialists. The plugin bundles **53 core agents** (Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO specialists) always loaded into `~/.claude/agents/`, plus **133 domain agent-packs** in `~/.claude/agent-packs/` that can be activated on demand. Boss selects the best-matching specialist from all active agents via Priority 2 capability matching. See [Installed Components](#installed-components) below.
+**Boss** is the only my-claude original agent. The remaining 9 are [OMO agents](https://github.com/code-yeongyu/oh-my-openagent) that Boss uses as sub-orchestrators and specialists. The plugin bundles **52 core agents** (Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO specialists) always loaded into `~/.claude/agents/`, plus **133 domain agent-packs** in `~/.claude/agent-packs/` that can be activated on demand. Boss selects the best-matching specialist from all active agents via Priority 2 capability matching. See [Installed Components](#installed-components) below.
 
 | Agent | Source | Model | Role |
 |---------|--------|------|------|
@@ -178,7 +178,7 @@ Following SETUP.md will configure the following:
 
 | Category | Count | Source | Bundled |
 |------|------|------|------|
-| Core Agents | 53 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
+| Core Agents | 52 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
 | Agent Packs | 133 | 12 domain categories (marketing, gamedev, sales, etc.) | Plugin |
 | Skills | 156 | ECC 125 + OMC 31 | Plugin |
 | Rules | 65 | ECC (common 9 + 8 languages × 5) | Plugin |
@@ -534,7 +534,7 @@ Every delegation includes a **6-section structured prompt**: TASK, EXPECTED OUTC
 ```
 $ claude "analyze auth module for security vulnerabilities"
 
-[Boss] Phase 0: Scanning... 186 agents, 156 skills ready.
+[Boss] Phase 0: Scanning... 185 agents, 156 skills ready.
 [Boss] Phase 1: Intent → Security Analysis | Priority: P2
 [Boss] Phase 2: Matched → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 All-in-One Claude Code Multi-Agent-Orchestrierungs-Plugin — einmal installieren, alles bekommen.
 
-Bündelt **186 Agenten**, **156 Skills**, **65 Regeln**, **6 Hooks** und **3 MCP-Server** aus 3 MIT-Upstream-Quellen in ein einzelnes Plugin. Der **Boss** dynamische Meta-Orchestrator entdeckt alle installierten Komponenten zur Laufzeit automatisch und leitet Aufgaben an den optimalen Spezialisten weiter. GitHub Actions CI synchronisiert Upstream-Änderungen wöchentlich.
+Bündelt **185 Agenten**, **156 Skills**, **65 Regeln**, **6 Hooks** und **3 MCP-Server** aus 3 MIT-Upstream-Quellen in ein einzelnes Plugin. Der **Boss** dynamische Meta-Orchestrator entdeckt alle installierten Komponenten zur Laufzeit automatisch und leitet Aufgaben an den optimalen Spezialisten weiter. GitHub Actions CI synchronisiert Upstream-Änderungen wöchentlich.
 
 <p align="center">
   <img src="../../assets/demo.svg" alt="my-claude demo" width="700">
@@ -108,7 +108,7 @@ Lese die vollständige Ausgabe und führe jeden Schritt der Reihe nach aus. Verw
 - **grep.app**: GitHub Open-Source-Code-Suche
 
 ### All-in-One Bundle
-- Plugin-Installation bietet sofort **186 Agenten, 156 Skills und 65 Regeln**
+- Plugin-Installation bietet sofort **185 Agenten, 156 Skills und 65 Regeln**
 - Bündelt 3 MIT-Upstream-Quellen (agency-agents, everything-claude-code, oh-my-claudecode)
 - Wöchentliche CI-Auto-Sync hält gebündelte Inhalte mit Upstream auf dem neuesten Stand
 - Begleitendes `install.sh` fügt npm-Tools und proprietäre Anthropic Skills hinzu
@@ -117,7 +117,7 @@ Lese die vollständige Ausgabe und führe jeden Schritt der Reihe nach aus. Verw
 
 ## Kern- + OMO-Agenten
 
-**Boss** ist der einzige my-claude Original-Agent. Die verbleibenden 9 sind [OMO-Agenten](https://github.com/code-yeongyu/oh-my-openagent), die Boss als Sub-Orchestrators und Spezialisten nutzt. Das Plugin bündelt **53 Kern-Agenten** (Kern 1 + OMO 9 + Engineering 23 + OMC 19 + OMO-Spezialisten), die immer in `~/.claude/agents/` geladen werden, plus **133 Domain-Agent-Packs** in `~/.claude/agent-packs/`, die bei Bedarf aktiviert werden können. Boss wählt den besten entsprechenden Spezialisten aus allen aktiven Agenten über Priority 2 Fähigkeits-Matching. Siehe [Installierte Komponenten](#installierte-komponenten) unten.
+**Boss** ist der einzige my-claude Original-Agent. Die verbleibenden 9 sind [OMO-Agenten](https://github.com/code-yeongyu/oh-my-openagent), die Boss als Sub-Orchestrators und Spezialisten nutzt. Das Plugin bündelt **52 Kern-Agenten** (Kern 1 + OMO 9 + Engineering 23 + OMC 19 + OMO-Spezialisten), die immer in `~/.claude/agents/` geladen werden, plus **133 Domain-Agent-Packs** in `~/.claude/agent-packs/`, die bei Bedarf aktiviert werden können. Boss wählt den besten entsprechenden Spezialisten aus allen aktiven Agenten über Priority 2 Fähigkeits-Matching. Siehe [Installierte Komponenten](#installierte-komponenten) unten.
 
 | Agent | Quelle | Modell | Rolle |
 |---------|--------|------|------|
@@ -170,7 +170,7 @@ Das Befolgen von SETUP.md konfiguriert Folgendes:
 
 | Kategorie | Anzahl | Quelle | Gebündelt |
 |------|------|------|------|
-| Kern-Agenten | 53 | Kern 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
+| Kern-Agenten | 52 | Kern 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
 | Agent Packs | 133 | 12 Domain-Kategorien (Marketing, Spieleentwicklung, Verkauf, etc.) | Plugin |
 | Skills | 156 | ECC 125 + OMC 31 | Plugin |
 | Regeln | 65 | ECC (Common 9 + 8 Sprachen × 5) | Plugin |
@@ -526,7 +526,7 @@ Jede Delegation beinhaltet einen **6-Abschnitt strukturierten Prompt**: AUFGABE,
 ```
 $ claude "analyze auth module for security vulnerabilities"
 
-[Boss] Phase 0: Scanning... 186 agents, 156 skills ready.
+[Boss] Phase 0: Scanning... 185 agents, 156 skills ready.
 [Boss] Phase 1: Intent → Security Analysis | Priority: P2
 [Boss] Phase 2: Matched → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 Plugin d'orchestration multi-agents Claude Code tout-en-un — installez une fois, obtenez tout.
 
-Regroupe **186 agents**, **156 skills**, **65 règles**, **6 hooks** et **3 serveurs MCP** issus de 3 sources upstream MIT dans un seul plugin. Le **Boss** méta-orchestrateur dynamique découvre automatiquement tous les composants installés au démarrage et route les tâches vers le spécialiste optimal. Une CI GitHub Actions synchronise les modifications upstream chaque semaine.
+Regroupe **185 agents**, **156 skills**, **65 règles**, **6 hooks** et **3 serveurs MCP** issus de 3 sources upstream MIT dans un seul plugin. Le **Boss** méta-orchestrateur dynamique découvre automatiquement tous les composants installés au démarrage et route les tâches vers le spécialiste optimal. Une CI GitHub Actions synchronise les modifications upstream chaque semaine.
 
 <p align="center">
   <img src="../../assets/demo.svg" alt="my-claude demo" width="700">
@@ -108,7 +108,7 @@ Lisez la sortie complète et exécutez chaque étape dans l'ordre. Utilisez `cur
 - **grep.app** : Recherche de code open source sur GitHub
 
 ### Bundle tout-en-un
-- L'installation via plugin fournit immédiatement **186 agents, 156 skills et 65 règles**
+- L'installation via plugin fournit immédiatement **185 agents, 156 skills et 65 règles**
 - Regroupe 3 sources upstream MIT (agency-agents, everything-claude-code, oh-my-claudecode)
 - La CI auto-sync hebdomadaire maintient le contenu groupé à jour avec l'upstream
 - Le `install.sh` d'accompagnement ajoute les outils npm et les Anthropic Skills propriétaires
@@ -117,7 +117,7 @@ Lisez la sortie complète et exécutez chaque étape dans l'ordre. Utilisez `cur
 
 ## Agents Cœur + OMO
 
-**Boss** est le seul agent original de my-claude. Les 9 restants sont des [agents OMO](https://github.com/code-yeongyu/oh-my-openagent) que Boss utilise comme sous-orchestrateurs et spécialistes. Le plugin regroupe **53 agents cœur** (Cœur 2 + OMO 9 + Engineering 23 + OMC 19) qui se chargent toujours dans `~/.claude/agents/`, plus **133 packs d'agents de domaine** dans `~/.claude/agent-packs/` pouvant être activés à la demande. Boss sélectionne le meilleur spécialiste parmi tous les agents actifs via la correspondance de capacités Priority 2. Voir [Composants installés](#composants-installés) ci-dessous.
+**Boss** est le seul agent original de my-claude. Les 9 restants sont des [agents OMO](https://github.com/code-yeongyu/oh-my-openagent) que Boss utilise comme sous-orchestrateurs et spécialistes. Le plugin regroupe **52 agents cœur** (Cœur 2 + OMO 9 + Engineering 23 + OMC 19) qui se chargent toujours dans `~/.claude/agents/`, plus **133 packs d'agents de domaine** dans `~/.claude/agent-packs/` pouvant être activés à la demande. Boss sélectionne le meilleur spécialiste parmi tous les agents actifs via la correspondance de capacités Priority 2. Voir [Composants installés](#composants-installés) ci-dessous.
 
 | Agent | Source | Modèle | Rôle |
 |---------|--------|------|------|
@@ -170,7 +170,7 @@ Suivre SETUP.md configure les éléments suivants :
 
 | Catégorie | Nombre | Source | Inclus dans |
 |------|------|------|------|
-| Agents cœur | 53 | Cœur 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
+| Agents cœur | 52 | Cœur 1 + OMO 9 + Engineering 23 + OMC 19 | Plugin |
 | Agent Packs | 133 | 12 catégories de domaine (Marketing, Développement de jeux, Vente, etc.) | Plugin |
 | Skills | 156 | ECC 125 + OMC 31 | Plugin |
 | Règles | 65 | ECC (Common 9 + 8 langages × 5) | Plugin |
@@ -526,7 +526,7 @@ Chaque délégation inclut un **prompt structuré en 6 sections** : TÂCHE, RÉS
 ```
 $ claude "analyze auth module for security vulnerabilities"
 
-[Boss] Phase 0: Scanning... 186 agents, 156 skills ready.
+[Boss] Phase 0: Scanning... 185 agents, 156 skills ready.
 [Boss] Phase 1: Intent → Security Analysis | Priority: P2
 [Boss] Phase 2: Matched → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 Claude Code 用の完全な複数エージェント オーケストレーション プラグイン — 1 回インストールするだけで、すべてが揃います。
 
-3 つの MIT アップストリーム ソースから **186 エージェント**、**156 スキル**、**65 ルール**、**6 つのフック**、**3 つの MCP サーバー** をバンドルして、1 つのプラグインにまとめています。**Boss** 動的メタ オーケストレータは、実行時にインストール済みのすべてのコンポーネントを自動検出し、最適な専門家にタスクをルーティングします。GitHub Actions CI は、アップストリームの変更を毎週同期します。
+3 つの MIT アップストリーム ソースから **185 エージェント**、**156 スキル**、**65 ルール**、**6 つのフック**、**3 つの MCP サーバー** をバンドルして、1 つのプラグインにまとめています。**Boss** 動的メタ オーケストレータは、実行時にインストール済みのすべてのコンポーネントを自動検出し、最適な専門家にタスクをルーティングします。GitHub Actions CI は、アップストリームの変更を毎週同期します。
 
 <p align="center">
   <img src="../../assets/demo.svg" alt="my-claude demo" width="700">
@@ -108,7 +108,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-claude/main/AI-INSTALL.md
 - **grep.app**: GitHub オープンソース コード検索
 
 ### ワンパッケージ バンドル
-- プラグイン インストールは **186 エージェント、156 スキル、65 ルール** を即座に提供
+- プラグイン インストールは **185 エージェント、156 スキル、65 ルール** を即座に提供
 - 3 つの MIT アップストリーム ソース（agency-agents、everything-claude-code、oh-my-claudecode）をバンドル
 - 毎週 CI オート同期によるアップストリーム コンテンツ最新化
 - コンパニオン `install.sh` は npm ツールと独自 Anthropic スキルを追加
@@ -117,7 +117,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-claude/main/AI-INSTALL.md
 
 ## コア + OMO エージェント
 
-**Boss** は my-claude の唯一のオリジナル エージェントです。残りの 9 つは [OMO エージェント](https://github.com/code-yeongyu/oh-my-openagent)で、Boss がサブ オーケストレータおよび専門家として使用します。プラグインは **53 のコア エージェント**（Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO 専門家）を `~/.claude/agents/` に常時ロードし、さらに **133 のドメイン エージェント パック**を `~/.claude/agent-packs/` に置いており、必要に応じて有効化できます。Boss は、すべてのアクティブなエージェントから優先度 2 の機能マッチングを通じて最適マッチ専門家を選択します。以下の[インストール済みコンポーネント](#installed-components)を参照してください。
+**Boss** は my-claude の唯一のオリジナル エージェントです。残りの 9 つは [OMO エージェント](https://github.com/code-yeongyu/oh-my-openagent)で、Boss がサブ オーケストレータおよび専門家として使用します。プラグインは **52 のコア エージェント**（Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO 専門家）を `~/.claude/agents/` に常時ロードし、さらに **133 のドメイン エージェント パック**を `~/.claude/agent-packs/` に置いており、必要に応じて有効化できます。Boss は、すべてのアクティブなエージェントから優先度 2 の機能マッチングを通じて最適マッチ専門家を選択します。以下の[インストール済みコンポーネント](#installed-components)を参照してください。
 
 | エージェント | ソース | モデル | 役割 |
 |---------|--------|------|------|
@@ -170,7 +170,7 @@ SETUP.md に従うと、以下が設定されます:
 
 | カテゴリ | 数 | ソース | バンドル |
 |------|------|------|------|
-| コア エージェント | 53 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | プラグイン |
+| コア エージェント | 52 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | プラグイン |
 | エージェント パック | 133 | 12 ドメイン カテゴリ（マーケティング、ゲーム開発、セールスなど） | プラグイン |
 | スキル | 156 | ECC 125 + OMC 31 | プラグイン |
 | ルール | 65 | ECC（共通 9 + 8 言語 × 5） | プラグイン |
@@ -526,7 +526,7 @@ Boss はすべてのリクエストを 4 レベル優先度チェーンを通じ
 ```
 $ claude "セキュリティ脆弱性について認証モジュール分析"
 
-[Boss] Phase 0: スキャン中... 186 エージェント、156 スキル準備完了.
+[Boss] Phase 0: スキャン中... 185 エージェント、156 スキル準備完了.
 [Boss] Phase 1: 意図 → セキュリティ分析 | 優先度: P2
 [Boss] Phase 2: マッチ → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 Claude Code 멀티에이전트 오케스트레이션 환경을 한 번에 구성하기 위한 레포지토리입니다.
 
-3개 MIT 업스트림 소스에서 **186개 에이전트**, **156개 스킬**, **65개 룰**, **6개 훅**, **3개 MCP 서버**를 하나의 플러그인에 번들. GitHub Actions CI가 매주 업스트림 변경사항을 자동 동기화. **Boss** 동적 메타 오케스트레이터가 런타임에 설치된 모든 에이전트, 스킬, MCP 서버를 자동 감지하고 최적의 전문가에게 작업을 라우팅합니다.
+3개 MIT 업스트림 소스에서 **185개 에이전트**, **156개 스킬**, **65개 룰**, **6개 훅**, **3개 MCP 서버**를 하나의 플러그인에 번들. GitHub Actions CI가 매주 업스트림 변경사항을 자동 동기화. **Boss** 동적 메타 오케스트레이터가 런타임에 설치된 모든 에이전트, 스킬, MCP 서버를 자동 감지하고 최적의 전문가에게 작업을 라우팅합니다.
 
 <p align="center">
   <img src="../../assets/demo.svg" alt="my-claude 데모" width="700">
@@ -107,14 +107,14 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-claude/main/AI-INSTALL.md
 - **grep.app**: GitHub 오픈소스 코드 검색
 
 ### 통합 생태계
-- 플러그인 하나로 **186 에이전트, 156 스킬, 65 룰**을 한 환경에 구성
+- 플러그인 하나로 **185 에이전트, 156 스킬, 65 룰**을 한 환경에 구성
 - 6개 오픈소스 도구(OMC, omo, ECC, Anthropic Skills, Agency, Karpathy)를 하나로 통합
 
 ---
 
 ## Core + OMO 에이전트
 
-**Boss**만 my-claude 고유 에이전트입니다. 나머지 9개는 Boss가 서브 오케스트레이터 및 전문가로 사용하는 [OMO 에이전트](https://github.com/code-yeongyu/oh-my-openagent)입니다. 플러그인은 **53개 코어 에이전트** (Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO 전문가)를 `~/.claude/agents/`에 항상 로드하며, **133개 도메인 에이전트 팩**은 `~/.claude/agent-packs/`에 설치되어 필요 시 활성화할 수 있습니다. Boss는 Priority 2 능력 매칭으로 활성화된 전체 에이전트 풀에서 최적의 전문가를 선택합니다. 전체 목록은 아래 [설치 후 전체 구성 요소](#설치-후-전체-구성-요소)를 참고하세요.
+**Boss**만 my-claude 고유 에이전트입니다. 나머지 9개는 Boss가 서브 오케스트레이터 및 전문가로 사용하는 [OMO 에이전트](https://github.com/code-yeongyu/oh-my-openagent)입니다. 플러그인은 **52개 코어 에이전트** (Core 1 + OMO 9 + Engineering 23 + OMC 19 + OMO 전문가)를 `~/.claude/agents/`에 항상 로드하며, **133개 도메인 에이전트 팩**은 `~/.claude/agent-packs/`에 설치되어 필요 시 활성화할 수 있습니다. Boss는 Priority 2 능력 매칭으로 활성화된 전체 에이전트 풀에서 최적의 전문가를 선택합니다. 전체 목록은 아래 [설치 후 전체 구성 요소](#설치-후-전체-구성-요소)를 참고하세요.
 
 | 에이전트 | 출처 | 모델 | 역할 |
 |---------|------|------|------|
@@ -167,7 +167,7 @@ SETUP.md를 따라 설치하면 다음이 구성됩니다:
 
 | 카테고리 | 개수 | 출처 | 번들 |
 |------|------|------|------|
-| 코어 에이전트 | 53 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | 플러그인 |
+| 코어 에이전트 | 52 | Core 1 + OMO 9 + Engineering 23 + OMC 19 | 플러그인 |
 | 에이전트 팩 | 133 | 12개 도메인 카테고리 (마케팅, 게임 개발, 영업 등) | 플러그인 |
 | 스킬 | 156 | ECC 125 + OMC 31 | 플러그인 |
 | 룰 | 65 | ECC (common 9 + 8 languages × 5) | 플러그인 |
@@ -519,7 +519,7 @@ Boss는 모든 요청을 4단계 우선순위 체인으로 라우팅합니다:
 ```
 $ claude "analyze auth module for security vulnerabilities"
 
-[Boss] Phase 0: Scanning... 186 agents, 156 skills ready.
+[Boss] Phase 0: Scanning... 185 agents, 156 skills ready.
 [Boss] Phase 1: Intent → Security Analysis | Priority: P2
 [Boss] Phase 2: Matched → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -13,7 +13,7 @@
 # my-claude
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![Agents](https://img.shields.io/badge/agents-186-blue)
+![Agents](https://img.shields.io/badge/agents-185-blue)
 ![Skills](https://img.shields.io/badge/skills-156-purple)
 ![Rules](https://img.shields.io/badge/rules-65-orange)
 ![MCP](https://img.shields.io/badge/MCP-3-green)
@@ -22,7 +22,7 @@
 
 一体化 Claude Code 多代理编排插件 — 安装一次，获得所有功能。
 
-捆绑了来自 3 个 MIT 上游来源的 **186 个代理**、**156 个技能**、**65 个规则**、**6 个钩子**和 **3 个 MCP 服务器**到单一插件中。**Boss** 动态元编排器在运行时自动发现所有已安装的组件，并将任务路由到最优专家。GitHub Actions CI 每周同步上游变更。
+捆绑了来自 3 个 MIT 上游来源的 **185 个代理**、**156 个技能**、**65 个规则**、**6 个钩子**和 **3 个 MCP 服务器**到单一插件中。**Boss** 动态元编排器在运行时自动发现所有已安装的组件，并将任务路由到最优专家。GitHub Actions CI 每周同步上游变更。
 
 <p align="center">
   <img src="../../assets/demo.svg" alt="my-claude demo" width="700">
@@ -108,7 +108,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-claude/main/AI-INSTALL.md
 - **grep.app**：GitHub 开源代码搜索
 
 ### 一体化包
-- 插件安装提供 **186 个代理、156 个技能和 65 个规则**，即时可用
+- 插件安装提供 **185 个代理、156 个技能和 65 个规则**，即时可用
 - 捆绑 3 个 MIT 上游来源（agency-agents、everything-claude-code、oh-my-claudecode）
 - 每周 CI 自动同步保持捆绑内容与上游最新
 - 伴随 `install.sh` 添加 npm 工具和专有 Anthropic 技能
@@ -117,7 +117,7 @@ curl -s https://raw.githubusercontent.com/sehoon787/my-claude/main/AI-INSTALL.md
 
 ## 核心 + OMO 代理
 
-**Boss** 是唯一的 my-claude 原创代理。其余 9 个是 [OMO 代理](https://github.com/code-yeongyu/oh-my-openagent)，Boss 用作子编排器和专家。该插件捆绑了 **53 个核心代理**（核心 1 + OMO 9 + 工程 23 + OMC 19 + OMO 专家）始终加载到 `~/.claude/agents/`，加上 **133 个领域代理包**在 `~/.claude/agent-packs/` 中，可以按需激活。Boss 通过优先级 2 能力匹配从所有活跃代理中选择最佳匹配的专家。请参见下面的 [已安装组件](#已安装组件)。
+**Boss** 是唯一的 my-claude 原创代理。其余 9 个是 [OMO 代理](https://github.com/code-yeongyu/oh-my-openagent)，Boss 用作子编排器和专家。该插件捆绑了 **52 个核心代理**（核心 1 + OMO 9 + 工程 23 + OMC 19 + OMO 专家）始终加载到 `~/.claude/agents/`，加上 **133 个领域代理包**在 `~/.claude/agent-packs/` 中，可以按需激活。Boss 通过优先级 2 能力匹配从所有活跃代理中选择最佳匹配的专家。请参见下面的 [已安装组件](#已安装组件)。
 
 | 代理 | 来源 | 模型 | 角色 |
 |---------|--------|------|------|
@@ -170,7 +170,7 @@ rm ~/.claude/agents/<agent-name>.md
 
 | 类别 | 数量 | 来源 | 捆绑 |
 |------|------|------|------|
-| 核心代理 | 53 | Core 1 + OMO 9 + 工程 23 + OMC 19 | 插件 |
+| 核心代理 | 52 | Core 1 + OMO 9 + 工程 23 + OMC 19 | 插件 |
 | 代理包 | 133 | 12 个领域类别（营销、游戏开发、销售等） | 插件 |
 | 技能 | 156 | ECC 125 + OMC 31 | 插件 |
 | 规则 | 65 | ECC（通用 9 + 8 种语言 × 5） | 插件 |
@@ -525,7 +525,7 @@ Boss 通过 4 级优先级链路由每个请求：
 ```
 $ claude "analyze auth module for security vulnerabilities"
 
-[Boss] Phase 0: 扫描中... 186 个代理，156 个技能就绪。
+[Boss] Phase 0: 扫描中... 185 个代理，156 个技能就绪。
 [Boss] Phase 1: 意图 → 安全分析 | 优先级：P2
 [Boss] Phase 2: 匹配 → security-reviewer (sonnet)
 [Boss] Agent(description="security review", model="sonnet", prompt="

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,15 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>my-claude — All-in-one Claude Code Multi-Agent Orchestration</title>
-<meta name="description" content="All-in-one Claude Code multi-agent orchestration plugin. 186 agents, 156 skills, 3 MCP servers. Boss discovers and orchestrates everything at runtime.">
+<meta name="description" content="All-in-one Claude Code multi-agent orchestration plugin. 185 agents, 156 skills, 3 MCP servers. Boss discovers and orchestrates everything at runtime.">
 <meta property="og:title" content="my-claude — All-in-one Claude Code Multi-Agent Orchestration">
-<meta property="og:description" content="186 agents, 156 skills, 65 rules, 3 MCP servers orchestrated by Boss — a dynamic meta-orchestrator that discovers capabilities at runtime. One plugin installs everything.">
+<meta property="og:description" content="185 agents, 156 skills, 65 rules, 3 MCP servers orchestrated by Boss — a dynamic meta-orchestrator that discovers capabilities at runtime. One plugin installs everything.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://sehoon787.github.io/my-claude/">
 <meta property="og:image" content="https://sehoon787.github.io/my-claude/assets/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="my-claude — Claude Code Multi-Agent Orchestration Plugin">
-<meta name="twitter:description" content="Boss orchestrates 186 agents, 156 skills, 3 MCP servers. Dynamic runtime discovery. One plugin.">
+<meta name="twitter:description" content="Boss orchestrates 185 agents, 156 skills, 3 MCP servers. Dynamic runtime discovery. One plugin.">
 <link rel="canonical" href="https://sehoon787.github.io/my-claude/">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -224,7 +224,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
   <p class="tagline">
     <span class="lang" data-en="Boss scans your system at runtime, matches capabilities, and routes every task to the perfect agent. No config files. No boilerplate." data-ko="Boss는 런타임에 시스템을 스캔하고, 능력을 매칭하여 모든 작업을 최적의 에이전트에 라우팅합니다. 설정 파일도, 보일러플레이트도 없습니다."></span>
   </p>
-  <p class="stat-tagline"><em data-count="186">0</em> <span class="lang" data-en="agents" data-ko="에이전트"></span> · <em data-count="156">0</em> <span class="lang" data-en="skills" data-ko="스킬"></span> · <em data-count="65">0</em> <span class="lang" data-en="rules" data-ko="규칙"></span> · <em>3</em> MCP</p>
+  <p class="stat-tagline"><em data-count="185">0</em> <span class="lang" data-en="agents" data-ko="에이전트"></span> · <em data-count="156">0</em> <span class="lang" data-en="skills" data-ko="스킬"></span> · <em data-count="65">0</em> <span class="lang" data-en="rules" data-ko="규칙"></span> · <em>3</em> MCP</p>
   <div class="badges">
     <span class="badge"><span class="lang" data-en="Zero Configuration" data-ko="무설정"></span></span>
     <span class="badge"><span class="lang" data-en="Runtime Discovery" data-ko="런타임 탐색"></span></span>
@@ -282,7 +282,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
           <div class="term-line t-dim">$ claude "<span class="lang" data-en="analyze auth module for security vulnerabilities" data-ko="auth 모듈 보안 취약점 분석해줘"></span>"</div>
           <div class="term-line"></div>
           <div class="term-line t-phase">── Phase 0: <span class="lang" data-en="Discovery" data-ko="탐색"></span> ──</div>
-          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 186 agents, 156 skills, 3 MCP servers ready." data-ko="스캔 중... 186 에이전트, 156 스킬, 3 MCP 서버 준비 완료."></span></div>
+          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 185 agents, 156 skills, 3 MCP servers ready." data-ko="스캔 중... 185 에이전트, 156 스킬, 3 MCP 서버 준비 완료."></span></div>
           <div class="term-line t-phase">── Phase 1: <span class="lang" data-en="Classification" data-ko="분류"></span> ──</div>
           <div class="term-line t-boss">[Boss] <span class="lang" data-en="Intent: Security Analysis | Scope: Read-only | Priority: P2" data-ko="의도: 보안 분석 | 범위: 읽기 전용 | 우선순위: P2"></span></div>
           <div class="term-line t-phase">── Phase 2: <span class="lang" data-en="Delegation" data-ko="위임"></span> ──</div>
@@ -298,7 +298,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
           <div class="term-line t-dim">$ claude "<span class="lang" data-en="refactor and code review please" data-ko="리팩토링하고 코드리뷰해줘"></span>"</div>
           <div class="term-line"></div>
           <div class="term-line t-phase">── Phase 0: <span class="lang" data-en="Discovery" data-ko="탐색"></span> ──</div>
-          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 186 agents, 156 skills, 3 MCP ready." data-ko="스캔 중... 186 에이전트, 156 스킬, 3 MCP 준비 완료."></span></div>
+          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 185 agents, 156 skills, 3 MCP ready." data-ko="스캔 중... 185 에이전트, 156 스킬, 3 MCP 준비 완료."></span></div>
           <div class="term-line t-phase">── Phase 1: <span class="lang" data-en="Classification" data-ko="분류"></span> ──</div>
           <div class="term-line t-boss">[Boss] <span class="lang" data-en="Intent: Refactor + Review | Multi-step → P3a Orchestration" data-ko="의도: 리팩토링 + 리뷰 | 멀티스텝 → P3a 오케스트레이션"></span></div>
           <div class="term-line t-phase">── Phase 2: <span class="lang" data-en="Delegation" data-ko="위임"></span> ──</div>
@@ -313,7 +313,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
           <div class="term-line t-dim">$ claude "<span class="lang" data-en="implement payment module with code review" data-ko="결제 모듈 구현하고 코드리뷰해줘"></span>"</div>
           <div class="term-line"></div>
           <div class="term-line t-phase">── Phase 0: <span class="lang" data-en="Discovery" data-ko="탐색"></span> ──</div>
-          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 186 agents, 156 skills, 3 MCP ready." data-ko="스캔 중... 186 에이전트, 156 스킬, 3 MCP 준비 완료."></span></div>
+          <div class="term-line t-boss">[Boss] <span class="lang" data-en="Scanning... 185 agents, 156 skills, 3 MCP ready." data-ko="스캔 중... 185 에이전트, 156 스킬, 3 MCP 준비 완료."></span></div>
           <div class="term-line t-phase">── Phase 1: <span class="lang" data-en="Classification" data-ko="분류"></span> ──</div>
           <div class="term-line t-boss">[Boss] <span class="lang" data-en="Intent: Implement + Review | Inter-agent comm needed → P3c Teams" data-ko="의도: 구현 + 리뷰 | 에이전트 간 통신 필요 → P3c 팀"></span></div>
           <div class="term-line t-phase">── Phase 2: <span class="lang" data-en="Team Setup" data-ko="팀 구성"></span> ──</div>
@@ -418,7 +418,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
 <section id="catalog" style="background:var(--bg2)">
 <div class="container">
   <h2 class="st"><span class="lang" data-en="Agent Catalog" data-ko="에이전트 목록"></span></h2>
-  <p class="ss"><span class="lang" data-en="186 agents across 4 tiers, from meta-orchestrator to domain specialists." data-ko="메타 오케스트레이터부터 도메인 전문가까지, 4개 계층에 걸친 186개 에이전트."></span></p>
+  <p class="ss"><span class="lang" data-en="185 agents across 4 tiers, from meta-orchestrator to domain specialists." data-ko="메타 오케스트레이터부터 도메인 전문가까지, 4개 계층에 걸친 185개 에이전트."></span></p>
   <div class="catalog fade-in">
     <details>
       <summary>Core <span class="cat-count">1 agent</span></summary>
@@ -480,7 +480,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
       <span class="fc-icon">&#x1f4e1;</span>
       <h4><span class="lang" data-en="Runtime Discovery" data-ko="런타임 탐색"></span></h4>
       <p><span class="lang" data-en="Boss scans your filesystem at session start. New agents appear instantly — no registration needed." data-ko="Boss는 세션 시작 시 파일시스템을 스캔합니다. 새 에이전트가 즉시 나타나며, 등록 과정이 필요 없습니다."></span></p>
-      <pre><em>Scan</em> ~/.claude/agents/    → 186 found
+      <pre><em>Scan</em> ~/.claude/agents/    → 185 found
 <em>Scan</em> ~/.claude/skills/    → 156 found
 <em>Scan</em> ~/.claude/settings   → 3 MCP
 <em>Ready</em> in 0.8s</pre>
@@ -488,7 +488,7 @@ footer{padding:40px 0;border-top:1px solid rgba(255,255,255,.06);text-align:cent
     <div class="feat-card">
       <span class="fc-icon">&#x26a1;</span>
       <h4><span class="lang" data-en="Zero Configuration" data-ko="무설정"></span></h4>
-      <p><span class="lang" data-en="Install once, get 186 agents. No YAML, no DAGs, no workflow definitions." data-ko="한 번 설치하면 186개 에이전트를 얻습니다. YAML도, DAG도, 워크플로우 정의도 없습니다."></span></p>
+      <p><span class="lang" data-en="Install once, get 185 agents. No YAML, no DAGs, no workflow definitions." data-ko="한 번 설치하면 185개 에이전트를 얻습니다. YAML도, DAG도, 워크플로우 정의도 없습니다."></span></p>
       <pre>git clone --depth 1 \
   https://github.com/sehoon787/my-claude \
   /tmp/my-claude
@@ -511,7 +511,7 @@ bash /tmp/my-claude/install.sh
     <tr><td><span class="lang" data-en="Runtime Discovery" data-ko="런타임 탐색"></span></td><td class="y">&#x2705;</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
     <tr><td><span class="lang" data-en="No Code Required" data-ko="코드 불필요"></span></td><td class="y">&#x2705;</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
     <tr><td><span class="lang" data-en="Claude Code Native" data-ko="Claude Code 네이티브"></span></td><td class="y">&#x2705;</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
-    <tr><td><span class="lang" data-en="186 Pre-built Agents" data-ko="186개 사전 구축 에이전트"></span></td><td class="y">&#x2705;</td><td>Custom</td><td>Custom</td></tr>
+    <tr><td><span class="lang" data-en="185 Pre-built Agents" data-ko="185개 사전 구축 에이전트"></span></td><td class="y">&#x2705;</td><td>Custom</td><td>Custom</td></tr>
     <tr><td><span class="lang" data-en="Behavioral Hooks" data-ko="행동 훅"></span></td><td class="y">&#x2705;</td><td class="n">&#x2717;</td><td class="n">&#x2717;</td></tr>
   </table>
 </div>
@@ -532,7 +532,7 @@ bash /tmp/my-claude/install.sh
     </div>
     <div class="faq-item">
       <button class="faq-q" onclick="toggleFaq(this)"><span class="lang" data-en="Do I need to configure anything?" data-ko="설정이 필요한가요?"></span><span></span></button>
-      <div class="faq-a"><div class="faq-a-inner"><span class="lang" data-en="No. Run the install script and you're done. my-claude ships with 186 agents, 156 skills, 65 rules, and 3 MCP server configurations out of the box. Everything works immediately." data-ko="아니요. 설치 스크립트를 실행하면 끝입니다. my-claude는 186개 에이전트, 156개 스킬, 65개 규칙, 3개 MCP 서버 설정을 기본 포함합니다. 모든 것이 즉시 작동합니다."></span></div></div>
+      <div class="faq-a"><div class="faq-a-inner"><span class="lang" data-en="No. Run the install script and you're done. my-claude ships with 185 agents, 156 skills, 65 rules, and 3 MCP server configurations out of the box. Everything works immediately." data-ko="아니요. 설치 스크립트를 실행하면 끝입니다. my-claude는 185개 에이전트, 156개 스킬, 65개 규칙, 3개 MCP 서버 설정을 기본 포함합니다. 모든 것이 즉시 작동합니다."></span></div></div>
     </div>
     <div class="faq-item">
       <button class="faq-q" onclick="toggleFaq(this)"><span class="lang" data-en="Can I add my own agents?" data-ko="나만의 에이전트를 추가할 수 있나요?"></span><span></span></button>

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,11 @@ existing.agent = existing.agent || 'boss';
 if ('${TMUX_AVAILABLE}' === '1' && !existing.teammateMode) {
   existing.teammateMode = 'tmux';
 }
+existing.mcpServers = Object.assign({}, existing.mcpServers, {
+  context7: { type: 'url', url: 'https://mcp.context7.com/mcp' },
+  exa: { type: 'url', url: 'https://mcp.exa.ai/mcp?tools=web_search_exa' },
+  grep_app: { type: 'url', url: 'https://mcp.grep.app' }
+});
 fs.writeFileSync(dest, JSON.stringify(existing, null, 2) + '\n');
 console.log('  settings.json merged');
 "
@@ -143,8 +148,13 @@ const src  = path.join('${SCRIPT_DIR}', 'hooks', 'hooks.json');
 const existing  = fs.existsSync(dest) ? JSON.parse(fs.readFileSync(dest, 'utf8')) : {};
 const srcHooks  = JSON.parse(fs.readFileSync(src, 'utf8')).hooks || {};
 existing.hooks  = existing.hooks || {};
+// Resolve plugin-relative paths for non-plugin installs
+const hooksDir = path.join(process.env.HOME, '.claude', 'hooks').replace(/\\\\/g, '/');
+let rawHooks = JSON.stringify(srcHooks);
+rawHooks = rawHooks.split('\${CLAUDE_PLUGIN_ROOT}/hooks').join(hooksDir);
+const resolvedHooks = JSON.parse(rawHooks);
 // Add/replace each hook event from hooks.json into settings.json
-for (const [event, entries] of Object.entries(srcHooks)) {
+for (const [event, entries] of Object.entries(resolvedHooks)) {
   existing.hooks[event] = entries;
 }
 fs.writeFileSync(dest, JSON.stringify(existing, null, 2) + '\n');

--- a/tests/boss-routing-scenarios.md
+++ b/tests/boss-routing-scenarios.md
@@ -334,5 +334,5 @@ security-reviewer, sisyphus, test-engineer, tracer, verifier, writer,
 
 ### Scenario: Plugin-scoped agent discovery
 **Input**: "Show me all available agents"
-**Expected**: Boss reports 186 agents (53 core + 133 packs) from the plugin bundle
+**Expected**: Boss reports 185 agents (52 core + 133 packs) from the plugin bundle
 **Verify**: Count includes all three subdirectories


### PR DESCRIPTION
## Summary

- **Root cause**: `sync-upstream.yml` counted `agent-teams-reference.md` as a core agent → 53 propagated to all docs. `install.sh` correctly excludes it → actual install is 52.
- **install.sh**: Added mcpServers merge to settings.json (Step 4), resolved `${CLAUDE_PLUGIN_ROOT}` path for non-plugin installs (Step 4b), escaped the variable to prevent bash `set -u` error
- **All docs**: Unified 53→52 core, 186→185 total across README, i18n, plugin.json, marketplace.json, tests, index.html

## Files changed (13)

| Category | Files | Change |
|----------|-------|--------|
| Root cause | `sync-upstream.yml` | Exclude `agent-teams-reference.md` from `CORE_AGENTS` |
| Install bugs | `install.sh` | +mcpServers merge, +hook path resolution, +bash escape |
| Install guide | `AI-INSTALL.md` | Counts aligned, mcpServers in Step 1b |
| Plugin metadata | `plugin.json`, `marketplace.json` | 53→52 |
| Docs | `README.md`, 5x i18n, `index.html` | 53→52, 186→185 |
| Tests | `boss-routing-scenarios.md` | 53→52, 186→185 |

## Test plan

- [x] Local smoke test: 52 agents, 65 rules (12 dirs), 3 MCP, 6 hooks (SessionStart resolved)
- [ ] CI validate job passes (JSON lint, agent frontmatter, YAML lint)
- [ ] Verify no remaining 53 core or 186 agent references
- [ ] Weekly sync produces correct counts on next run