### PR TITLE
fix: unify agent-pack naming and add version tracking

### DIFF
--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -21,6 +21,8 @@ After plugin install, configure Boss and MCP servers globally:
 node -e "const fs=require('fs'),p=require('path'),f=p.join(require('os').homedir(),'.claude','settings.json');const s=fs.existsSync(f)?JSON.parse(fs.readFileSync(f,'utf8')):{};s.env={...s.env,CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:'1'};s.agent=s.agent||'boss';s.mcpServers={...s.mcpServers,context7:{type:'url',url:'https://mcp.context7.com/mcp'},exa:{type:'url',url:'https://mcp.exa.ai/mcp?tools=web_search_exa'},grep_app:{type:'url',url:'https://mcp.grep.app'}};fs.writeFileSync(f,JSON.stringify(s,null,2))"
 ```
 
+The plugin records its version automatically. To check: `cat ~/.claude/.my-claude-version`
+
 This installs:
 - 52 core agents in ~/.claude/agents/ (always loaded): Boss, 9 OMO, 19 OMC, 23 engineering
 - 133 domain agent-packs in ~/.claude/agent-packs/ (on-demand via symlink)
@@ -40,6 +42,10 @@ mkdir -p ~/.claude/agents ~/.claude/agent-packs ~/.claude/skills ~/.claude/rules
 for prefix in marketing- sales- paid- academic- design- support- testing- specialized- product- project-management- game- godot- unity- unreal- roblox- xr- phase- scenario-; do
   rm -f ~/.claude/agents/${prefix}*.md
 done
+# Clean up old-named agent-pack directories
+rm -rf ~/.claude/agent-packs/gamedev
+rm -rf ~/.claude/agent-packs/project-mgmt
+rm -rf ~/.claude/agent-packs/strategy
 # Core agents (always loaded)
 cp /tmp/my-claude/agents/core/boss.md /tmp/my-claude/agents/omo/*.md ~/.claude/agents/
 cp /tmp/my-claude/agents/omc/*.md ~/.claude/agents/
@@ -59,6 +65,8 @@ cp -r /tmp/my-claude/rules/* ~/.claude/rules/
 claude mcp add --transport http --scope user context7 "https://mcp.context7.com/mcp"
 claude mcp add --transport http --scope user exa "https://mcp.exa.ai/mcp?tools=web_search_exa"
 claude mcp add --transport http --scope user grep_app "https://mcp.grep.app"
+# Record installed version
+node -e "const v=require('/tmp/my-claude/.claude-plugin/plugin.json').version;require('fs').writeFileSync(require('path').join(require('os').homedir(),'.claude','.my-claude-version'),v+'\n')"
 rm -rf /tmp/my-claude
 ```
 
@@ -128,6 +136,7 @@ echo "Rules:            $(find ~/.claude/rules -name '*.md' 2>/dev/null | wc -l)
 echo "Anthropic skills: $(ls -d ~/.claude/skills/pdf ~/.claude/skills/docx 2>/dev/null | wc -l) key skills"
 echo "omc:              $(command -v omc >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo "omo:              $(command -v oh-my-opencode >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
+echo "Version:          $(cat ~/.claude/.my-claude-version 2>/dev/null || echo 'unknown')"
 ```
 
 Expected:
@@ -138,5 +147,6 @@ Expected:
 - Anthropic skills: 2 key skills (pdf, docx)
 - omc: OK
 - omo: OK
+- Version: matches latest release
 
 Setup complete. Boss orchestrator is ready.

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,20 @@ command -v npm  >/dev/null 2>&1 || { echo "ERROR: npm not found"; exit 1; }
 command -v git  >/dev/null 2>&1 || { echo "ERROR: git not found"; exit 1; }
 echo "  Prerequisites OK"
 
+# ── Version info ──
+INSTALLING_VERSION=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$SCRIPT_DIR/.claude-plugin/plugin.json','utf8')).version)}catch(e){console.log('unknown')}" 2>/dev/null)
+INSTALLED_VERSION="none"
+if [ -f "$HOME/.claude/.my-claude-version" ]; then
+  INSTALLED_VERSION=$(cat "$HOME/.claude/.my-claude-version")
+fi
+if [ "$INSTALLED_VERSION" = "none" ]; then
+  echo "  Fresh install: v${INSTALLING_VERSION}"
+elif [ "$INSTALLED_VERSION" = "$INSTALLING_VERSION" ]; then
+  echo "  Reinstalling: v${INSTALLING_VERSION} (same version)"
+else
+  echo "  Updating: v${INSTALLED_VERSION} → v${INSTALLING_VERSION}"
+fi
+
 # ── 0b. tmux (optional — for Agent Teams split-pane mode) ──
 echo "[0b] Checking tmux..."
 if command -v tmux >/dev/null 2>&1; then
@@ -53,9 +67,9 @@ echo "[1/6] Installing plugin files..."
 #   ~/.claude/docs/nexus/  → strategy docs (reference material, never parsed as agents)
 mkdir -p "$HOME/.claude/agents" "$HOME/.claude/skills" "$HOME/.claude/rules"
 mkdir -p "$HOME/.claude/agent-packs/academic" "$HOME/.claude/agent-packs/design" \
-         "$HOME/.claude/agent-packs/gamedev" "$HOME/.claude/agent-packs/marketing" \
+         "$HOME/.claude/agent-packs/game-development" "$HOME/.claude/agent-packs/marketing" \
          "$HOME/.claude/agent-packs/paid-media" "$HOME/.claude/agent-packs/product" \
-         "$HOME/.claude/agent-packs/project-mgmt" "$HOME/.claude/agent-packs/sales" \
+         "$HOME/.claude/agent-packs/project-management" "$HOME/.claude/agent-packs/sales" \
          "$HOME/.claude/agent-packs/spatial-computing" "$HOME/.claude/agent-packs/specialized" \
          "$HOME/.claude/agent-packs/support" "$HOME/.claude/agent-packs/testing"
 mkdir -p "$HOME/.claude/docs/nexus"
@@ -66,6 +80,12 @@ for prefix in marketing- sales- paid- academic- design- support- testing- specia
   rm -f "$HOME/.claude/agents/${prefix}"*.md
 done
 
+# Clean up old-named agent-pack directories from previous installs
+echo "  Cleaning up old naming variants..."
+rm -rf "$HOME/.claude/agent-packs/gamedev"
+rm -rf "$HOME/.claude/agent-packs/project-mgmt"
+rm -rf "$HOME/.claude/agent-packs/strategy"
+
 # agents — core tier (always loaded)
 find "$SCRIPT_DIR/agents/core" -maxdepth 1 -name '*.md' ! -name 'agent-teams-reference.md' -exec cp {} "$HOME/.claude/agents/" \;
 cp "$SCRIPT_DIR"/agents/omo/*.md  "$HOME/.claude/agents/"
@@ -75,11 +95,11 @@ cp -r "$SCRIPT_DIR"/agents/agency/engineering/*.md "$HOME/.claude/agents/"
 # agent-packs — domain agents (not auto-loaded)
 cp -r "$SCRIPT_DIR"/agents/agency/academic/*.md            "$HOME/.claude/agent-packs/academic/"
 cp -r "$SCRIPT_DIR"/agents/agency/design/*.md              "$HOME/.claude/agent-packs/design/"
-find "$SCRIPT_DIR/agents/agency/game-development" -name '*.md' -exec cp {} "$HOME/.claude/agent-packs/gamedev/" \;
+find "$SCRIPT_DIR/agents/agency/game-development" -name '*.md' -exec cp {} "$HOME/.claude/agent-packs/game-development/" \;
 cp -r "$SCRIPT_DIR"/agents/agency/marketing/*.md           "$HOME/.claude/agent-packs/marketing/"
 cp -r "$SCRIPT_DIR"/agents/agency/paid-media/*.md          "$HOME/.claude/agent-packs/paid-media/"
 cp -r "$SCRIPT_DIR"/agents/agency/product/*.md             "$HOME/.claude/agent-packs/product/"
-cp -r "$SCRIPT_DIR"/agents/agency/project-management/*.md  "$HOME/.claude/agent-packs/project-mgmt/"
+cp -r "$SCRIPT_DIR"/agents/agency/project-management/*.md  "$HOME/.claude/agent-packs/project-management/"
 cp -r "$SCRIPT_DIR"/agents/agency/sales/*.md               "$HOME/.claude/agent-packs/sales/"
 cp -r "$SCRIPT_DIR"/agents/agency/spatial-computing/*.md   "$HOME/.claude/agent-packs/spatial-computing/"
 cp -r "$SCRIPT_DIR"/agents/agency/specialized/*.md         "$HOME/.claude/agent-packs/specialized/"
@@ -241,6 +261,10 @@ echo "  omo:              $(command -v oh-my-opencode >/dev/null 2>&1 && echo 'O
 echo "  ast-grep:         $(command -v ast-grep       >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo "  tmux:             $(command -v tmux >/dev/null 2>&1 && echo "OK ($(tmux -V))" || echo 'NOT INSTALLED (in-process mode)')"
 TEAMMATE_MODE=$(node -e 'try{console.log(JSON.parse(require("fs").readFileSync(process.env.HOME+"/.claude/settings.json","utf8")).teammateMode||"auto")}catch(e){console.log("auto")}')
+echo "  version:          v${INSTALLING_VERSION}"
 echo "  teammateMode:     $TEAMMATE_MODE"
 echo ""
+# Record installed version
+echo "$INSTALLING_VERSION" > "$HOME/.claude/.my-claude-version"
+
 echo "=== Install complete ==="


### PR DESCRIPTION
## Summary

- **Naming fix**: `install.sh` used `gamedev`/`project-mgmt` while plugin and `AI-INSTALL.md` used `game-development`/`project-management` → unified to source repo names
- **Cleanup**: added `rm -rf` for old naming variants (`gamedev`, `project-mgmt`, `strategy`) on re-install
- **Version tracking**: reads version from `plugin.json`, compares with `~/.claude/.my-claude-version`, shows Fresh/Update/Reinstall, records after install

## Problem

Running both Step 1 (plugin) and Step 2 (`install.sh`) created **duplicate** agent-pack directories:

| Source | game agents dir | project agents dir |
|--------|----------------|-------------------|
| Plugin/Step 1b | `game-development/` | `project-management/` |
| install.sh | `gamedev/` | `project-mgmt/` |

Result: 175 agent-packs instead of expected 133 (+42 duplicates).

The existing clean step only removed old flat agents from `~/.claude/agents/`, not duplicate directories in `agent-packs/`.

## Changes

### install.sh
- `gamedev` → `game-development` in `mkdir` and `cp` commands
- `project-mgmt` → `project-management` in `mkdir` and `cp` commands
- Added cleanup block for old naming variants before file copy
- Added version info section (Fresh install / Updating / Reinstalling)
- Added version recording to `~/.claude/.my-claude-version`
- Added version display in `[6/6] Verification`

### AI-INSTALL.md
- Added old naming cleanup in Step 1b manual install
- Added version recording before `rm -rf /tmp/my-claude`
- Added version check note in Step 1
- Added version display in Verify section

## Test plan

- [ ] Fresh install: verify `~/.claude/.my-claude-version` is created with correct version
- [ ] Re-install over old naming: verify `gamedev/`, `project-mgmt/`, `strategy/` are removed
- [ ] Verify agent-packs count = 133 after install
- [ ] `bash -n install.sh` syntax check passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)