### PR TITLE
feat(models): move Boss to Claude Fable 5.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ model: claude-sonnet-5
 
 | Model | Use For |
 |-------|---------|
-| `claude-fable-5` | Top-level orchestration (Boss) — highest-capability meta-routing |
+| `claude-fable-5-1` | Top-level orchestration (Boss) — highest-capability meta-routing |
 | `claude-opus-5` | Deep reasoning, architecture, complex analysis |
 | `claude-sonnet-5` | Standard development work, orchestration |
 | `claude-haiku-4-5` | Fast lookups, lightweight agents, frequent invocation |

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Boss cascades every request through a priority chain until the best match is fou
 
 | Complexity | Model | Used For |
 |-----------|-------|----------|
-| Top-level orchestration | `claude-fable-5` | Boss |
+| Top-level orchestration | `claude-fable-5-1` | Boss |
 | Deep analysis, architecture | `claude-opus-5` | Sisyphus, Atlas, Hephaestus, Oracle, Metis, Momus, Prometheus |
 | Standard implementation | `claude-sonnet-5` | Librarian, Multimodal-Looker, OMC specialists |
 | Quick lookup, exploration | `claude-haiku-4-5` | Lightweight OMC agents, simple advisory |

--- a/SETUP.md
+++ b/SETUP.md
@@ -215,7 +215,7 @@ All 32 agents load on every session — there are no on-demand packs to activate
 
 | Group | Count | Path | Models | Effort |
 |-------|------:|------|--------|--------|
-| Boss meta-orchestrator | 1 | `~/.claude/agents/boss.md` | `claude-fable-5` | `xhigh` |
+| Boss meta-orchestrator | 1 | `~/.claude/agents/boss.md` | `claude-fable-5-1` | `xhigh` |
 | OMO sub-orchestrators and specialists | 9 | `~/.claude/agents/` | 7× `claude-opus-5`, 2× `claude-sonnet-5` | 2× `xhigh`, 5× `high`, 2× `medium` |
 | OMC specialists | 19 | `~/.claude/agents/` | opus / sonnet / haiku per agent | not set (upstream defaults) |
 | Vendored engineering agents | 3 | `~/.claude/agents/` | inherited from the caller | 1× `xhigh`, 2× `medium` |

--- a/agents/core/boss.md
+++ b/agents/core/boss.md
@@ -1,7 +1,7 @@
 ---
 name: boss
 description: Dynamic meta-orchestrator — auto-discovers all installed agents, skills, MCP tools, and hooks at runtime, then routes tasks to the optimal specialist. Replaces static routing with capability matching. (Fable)
-model: claude-fable-5
+model: claude-fable-5-1
 effort: xhigh
 ---
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -125,7 +125,7 @@ Boss leitet jede Anfrage durch eine Prioritätskette, bis die beste Übereinstim
 
 | Komplexität | Modell | Verwendet für |
 |-------------|--------|---------------|
-| Orchestrierung auf oberster Ebene | `claude-fable-5` | Boss |
+| Orchestrierung auf oberster Ebene | `claude-fable-5-1` | Boss |
 | Tiefgehende Analyse, Architektur | `claude-opus-5` | Sisyphus, Atlas, Hephaestus, Oracle, Metis, Momus, Prometheus |
 | Standardimplementierung | `claude-sonnet-5` | Librarian, Multimodal-Looker, OMC-Spezialisten |
 | Schnelle Suche, Erkundung | `claude-haiku-4-5` | Leichtgewichtige OMC-Agenten, einfache Beratung |

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -130,7 +130,7 @@ Boss cascade chaque requête dans une chaîne de priorités jusqu'à trouver la 
 
 | Complexité | Modèle | Utilisé pour |
 |-----------|-------|----------|
-| Orchestration de haut niveau | `claude-fable-5` | Boss |
+| Orchestration de haut niveau | `claude-fable-5-1` | Boss |
 | Analyse approfondie, architecture | `claude-opus-5` | Sisyphus, Atlas, Hephaestus, Oracle, Metis, Momus, Prometheus |
 | Implémentation standard | `claude-sonnet-5` | Librarian, Multimodal-Looker, spécialistes OMC |
 | Recherche rapide, exploration | `claude-haiku-4-5` | Agents OMC légers, conseil simple |

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -125,7 +125,7 @@ Boss はすべてのリクエストを優先チェーンにカスケードし、
 
 | 複雑度 | モデル | 使用場面 |
 |-----------|-------|----------|
-| トップレベルのオーケストレーション | `claude-fable-5` | Boss |
+| トップレベルのオーケストレーション | `claude-fable-5-1` | Boss |
 | 深い分析、アーキテクチャ | `claude-opus-5` | Sisyphus、Atlas、Hephaestus、Oracle、Metis、Momus、Prometheus |
 | 標準的な実装 | `claude-sonnet-5` | Librarian、Multimodal-Looker、OMC スペシャリスト |
 | 簡単な検索、調査 | `claude-haiku-4-5` | 軽量な OMC エージェント、簡易アドバイザリー |

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -164,7 +164,7 @@ Boss는 가장 적합한 매칭을 찾을 때까지 모든 요청을 우선순�
 
 | 복잡도 | 모델 | 사용 대상 |
 |-----------|-------|----------|
-| 최상위 오케스트레이션 | `claude-fable-5` | Boss |
+| 최상위 오케스트레이션 | `claude-fable-5-1` | Boss |
 | 심층 분석, 아키텍처 | `claude-opus-5` | Sisyphus, Atlas, Hephaestus, Oracle, Metis, Momus, Prometheus |
 | 표준 구현 | `claude-sonnet-5` | Librarian, Multimodal-Looker, OMC 전문가 |
 | 빠른 조회, 탐색 | `claude-haiku-4-5` | 경량 OMC 에이전트, 간단한 자문 |

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -125,7 +125,7 @@ Boss 对每个请求按优先级链逐级匹配，直到找到最佳方案：
 
 | 复杂度 | 模型 | 用途 |
 |-----------|-------|----------|
-| 顶层编排 | `claude-fable-5` | Boss |
+| 顶层编排 | `claude-fable-5-1` | Boss |
 | 深度分析、架构 | `claude-opus-5` | Sisyphus、Atlas、Hephaestus、Oracle、Metis、Momus、Prometheus |
 | 标准实现 | `claude-sonnet-5` | Librarian、Multimodal-Looker、OMC 专家 Agent |
 | 快速查询、探索 | `claude-haiku-4-5` | 轻量 OMC Agent、简单咨询 |

--- a/scripts/check-model-drift.sh
+++ b/scripts/check-model-drift.sh
@@ -13,7 +13,7 @@
 # Check 2 exists because check 1 cannot catch a nonexistent ID — it only knows
 # what to reject, not what to accept.
 #
-# Current generation (do NOT flag): claude-fable-5, claude-opus-5,
+# Current generation (do NOT flag): claude-fable-5-1, claude-opus-5,
 # claude-sonnet-5, claude-haiku-4-5.
 #
 # To roll forward on the next model generation, update OLD_MODEL_PATTERN,
@@ -33,7 +33,9 @@ set -uo pipefail
 # current generation moves forward. Overridable via env for local testing;
 # CI (smoke.yml) calls this script with no override, so this default is the
 # single source of truth — do not duplicate it elsewhere.
-OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-claude-opus-4-[0-9]|claude-sonnet-4-[0-9]|claude-haiku-4-[0-4]|claude-(2|3)([.-]|$)}"
+# `claude-fable-5([^-]|$)` matches the superseded Fable 5 without touching
+# Fable 5.1 — the trailing guard is what keeps `claude-fable-5-1` out of it.
+OLD_MODEL_PATTERN="${OLD_MODEL_PATTERN:-claude-opus-4-[0-9]|claude-sonnet-4-[0-9]|claude-haiku-4-[0-4]|claude-fable-5([^-]|\$)|claude-(2|3)([.-]|\$)}"
 
 # Path fragments to exclude from the scan (grep -E, matched against file path).
 #   - this script : VALID_MODELS below spells out real IDs, so the stale-ID
@@ -68,7 +70,7 @@ if [ -n "$hits" ]; then
   echo "FAIL: stale (previous-generation) model IDs found:"
   echo "$hits" | sed 's/^/  /'
   echo ""
-  echo "Update these to the current generation (claude-fable-5 / claude-opus-5 / claude-sonnet-5 / claude-haiku-4-5),"
+  echo "Update these to the current generation (claude-fable-5-1 / claude-opus-5 / claude-sonnet-5 / claude-haiku-4-5),"
   echo "or add a deliberate exception to EXCLUDE_PATHS in scripts/check-model-drift.sh."
   status=1
 fi
@@ -90,7 +92,7 @@ fi
 # generation — OLD_MODEL_PATTERN above already rejects them. Listing them as
 # valid here would put the two checks in direct contradiction. Bare aliases
 # are included because Claude Code resolves them and upstream agents use them.
-VALID_MODELS="${VALID_MODELS:-claude-fable-5 claude-mythos-5 claude-opus-5 claude-sonnet-5 claude-haiku-4-5 opus sonnet haiku}"
+VALID_MODELS="${VALID_MODELS:-claude-fable-5-1 claude-mythos-5 claude-opus-5 claude-sonnet-5 claude-haiku-4-5 opus sonnet haiku}"
 
 unknown=""
 while IFS= read -r line; do


### PR DESCRIPTION
Anthropic shipped **Claude Fable 5.1** and moved Claude Fable 5 to the [legacy list](https://platform.claude.com/docs/en/about-claude/models/overview.md). Boss — the only agent on the Fable tier — was pinned to a superseded model.

## The ID is `claude-fable-5-1`, hyphenated

Confirmed against the models overview page, **not inferred**. `claude-fable-5.1` is not a valid ID.

That verification step matters: guessing the shape of a model slug is exactly how the sibling `my-codex` repo ended up shipping a bare `gpt-5.6` the API never served, which then hid behind a runtime repair for weeks.

| | Before | After |
|---|---|---|
| `agents/core/boss.md` | `claude-fable-5` | `claude-fable-5-1` |
| README / SETUP / CONTRIBUTING | `claude-fable-5` | `claude-fable-5-1` |
| 5 translated READMEs (de/fr/ja/ko/zh) | `claude-fable-5` | `claude-fable-5-1` |

Docs updated alongside the pin so they do not disagree with what ships.

## The drift check moves with it

`claude-fable-5` joins `OLD_MODEL_PATTERN`, and `VALID_MODELS` now lists `claude-fable-5-1`:

```
claude-fable-5([^-]|$)
```

**The trailing guard is load-bearing.** Without it the pattern also matches `claude-fable-5-1` and the check would reject the current model as stale — a self-inflicted CI failure on every run.

## Verification (macOS, bash 3.2)

| case | expected | result |
|---|---|---|
| clean repo | pass | ✅ 74 files, 13 agent models recognised |
| Boss reverted to `claude-fable-5` | fail | ✅ caught by blacklist |
| made-up `claude-fable-5-2` | fail | ✅ caught by allowlist |
| pattern vs `claude-fable-5` | match | ✅ (prose + frontmatter) |
| pattern vs `claude-fable-5-1` | no match | ✅ (prose + frontmatter) |

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p