### PR TITLE
feat(boss): structured final report at end of turn, enforced by a Stop hook

### DIFF
--- a/agents/core/boss.md
+++ b/agents/core/boss.md
@@ -283,4 +283,30 @@ For anti-duplication rules and AI-slop detection patterns, see `boss-advanced` s
 - **On completion**: Summary of all changes with file list, test results, and any caveats.
 - **Language**: Match the user's language. Korean request -> Korean responses.
 
+---
+
+## FINAL REPORT (End of Every Working Turn)
+
+This section runs at the VERY END of your reasoning — after all delegation, verification, and side work is complete. Never emit it mid-task as a progress update; progress updates stay in TONE & STYLE's milestone format.
+
+**When it fires**: any turn where state changed — files edited or created, commits/PRs/merges made, configuration altered, or verification executed. Pure Q&A, explanations, and turns where nothing changed (including failed attempts that altered nothing) end normally without it.
+
+**Format**: close your reply with a concise final report assembled from the tables below. Include ONLY the tables whose situation occurred; never emit an empty table or invent rows to fill one. Precede the tables with at most 2-3 sentences of summary — the tables carry the detail.
+
+| Situation | Table | Columns |
+|-----------|-------|---------|
+| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
+| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
+| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
+| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
+| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+
+Rules:
+- Before/After tables are MANDATORY whenever you modified existing files or settings — the reader must see what changed without opening a diff.
+- Every 검증 결과 row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
+- 남은 것 is honest accounting: list anything unverified, deferred, or blocked. An empty "Remaining" claim with unresolved work is worse than a long one.
+- Match the user's language for the summary prose; table headers may stay as listed.
+
+Enforcement: the `stop-final-report.js` Stop hook checks the turn's final message and blocks once with a reminder if work happened but no report is present. Write the report on your own — the hook is the safety net, not the trigger.
+
 </Agent_Prompt>

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -138,6 +138,12 @@
             "command": "node \"$HOME/.claude/hooks/session-end.js\"",
             "timeout": 30000,
             "description": "BriefingVault v2: auto-create session/learning/decision scaffolds and suggest archives/wiki"
+          },
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks/stop-final-report.js\"",
+            "timeout": 5000,
+            "description": "FinalReport: blocks once per turn if work happened but the final message lacks the boss.md FINAL REPORT tables"
           }
         ]
       }

--- a/hooks/stop-final-report.js
+++ b/hooks/stop-final-report.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+'use strict';
+// stop-final-report.js — require a structured final report when work happened.
+//
+// Boss's prompt (boss.md § FINAL REPORT) defines WHAT the report looks like;
+// this hook is the enforcement half: a prompt rule alone is advisory and the
+// model can skip it, so the Stop hook checks the turn's actual final text and
+// blocks once when the report is missing.
+//
+// Judgment inputs come straight from the harness — no transcript parsing:
+//   - `last_assistant_message` (Stop hook input) is the final assistant text.
+//   - "did work happen" is the delta of .briefing/state.json's workCounter
+//     (incremented by the PostToolUse Edit|Write hook) since the last
+//     acknowledged report, so a session-long counter doesn't re-trigger on
+//     later chat-only turns.
+//
+// Loop safety (there is no built-in circuit breaker for Stop blocks):
+//   - blocks at most ONCE per prompt_id; on the second Stop of the same turn
+//     it acknowledges and lets the turn end even if the model ignored us.
+//   - fails open on any error — a broken hook must never trap the session.
+try {
+  var fs = require('fs');
+  var path = require('path');
+
+  var BRIEFING_DIR = '.briefing';
+  var INDEX_FILE = path.join(BRIEFING_DIR, 'INDEX.md');
+  var STATE_FILE = path.join(BRIEFING_DIR, 'state.json');
+
+  if (!fs.existsSync(INDEX_FILE)) { process.exit(0); }
+
+  var input = {};
+  try { input = JSON.parse(fs.readFileSync(0, 'utf8')); } catch (e) { process.exit(0); }
+
+  // Older harnesses may not send last_assistant_message — nothing to judge.
+  var lam = input.last_assistant_message;
+  if (typeof lam !== 'string' || lam.length === 0) { process.exit(0); }
+
+  var promptId = String(input.prompt_id || input.session_id || '');
+
+  function readState() {
+    try { return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')); } catch (e) { return {}; }
+  }
+  function writeState(update) {
+    try {
+      var s = readState();
+      var fr = Object.assign({}, s.finalReport || {}, update);
+      fs.writeFileSync(STATE_FILE, JSON.stringify(Object.assign({}, s, { finalReport: fr }), null, 2), 'utf8');
+    } catch (e) {}
+  }
+
+  var state = readState();
+  var wc = parseInt(state.workCounter, 10) || 0;
+  var fr = state.finalReport || {};
+  var acked = parseInt(fr.ackWorkCounter, 10) || 0;
+
+  // No NEW work since the last acknowledged report → chat-only turn, pass.
+  if (wc <= acked) { process.exit(0); }
+
+  // Report present? Markdown table rows (at least a header + one data row)
+  // or an explicit final-report heading — matching boss.md's spec.
+  var tableRows = (lam.match(/^\s*\|.*\|\s*$/gm) || []).length;
+  var hasHeading = /(^|\n)#{1,4}\s*.{0,24}(최종 보고|Final Report)/i.test(lam);
+  if (tableRows >= 2 || hasHeading) {
+    writeState({ ackWorkCounter: wc });
+    process.exit(0);
+  }
+
+  // Already blocked once this turn → give up gracefully (loop guard).
+  if (promptId && fr.blockedPromptId === promptId) {
+    writeState({ ackWorkCounter: wc });
+    process.exit(0);
+  }
+
+  // Language from INDEX.md frontmatter.
+  var isKo = false;
+  try {
+    var m = fs.readFileSync(INDEX_FILE, 'utf8').match(/^language:\s*(\S+)/m);
+    isKo = !!m && (m[1] === 'ko' || m[1] === 'kr');
+  } catch (e) {}
+
+  var reason = isKo
+    ? '[FinalReport] 이번 턴에 작업이 있었는데 최종 보고가 없습니다. 답변 마지막에 boss.md의 FINAL REPORT 규격대로 정리하세요: 해당되는 표만 골라 (변경 대조: 대상/Before/After/근거), (작업 요약: 항목/결과/근거), (검증 결과: 항목/기대/실제/판정), (산출물: PR/저장소/내용/상태), (남은 것: 항목/상태/다음 조치). 해당 없는 표는 생략하고 빈 표는 만들지 마세요.'
+    : '[FinalReport] Work happened this turn but the final report is missing. End your reply with the FINAL REPORT spec from boss.md: include only the applicable tables — (Changes: Target/Before/After/Why), (Work summary: Item/Result/Evidence), (Verification: Item/Expected/Actual/Verdict), (Deliverables: PR/Repo/Content/Status), (Remaining: Item/Status/Next step). Skip tables that do not apply; never emit an empty table.';
+
+  writeState({ blockedPromptId: promptId });
+  process.stdout.write(JSON.stringify({ decision: 'block', reason: reason }) + '\n');
+  process.exit(0);
+} catch (e) { process.exit(0); }

--- a/install.sh
+++ b/install.sh
@@ -475,11 +475,12 @@ cp "$SCRIPT_DIR/hooks/hooks.json"                "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/session-start.sh"           "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/stop-profile-update.js"     "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/stop-session-enforcement.js" "$HOME/.claude/hooks/"
+cp "$SCRIPT_DIR/hooks/stop-final-report.js"        "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/persona-rule.js"             "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/briefing-runtime.js"         "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/session-sync.js"             "$HOME/.claude/hooks/"
 cp "$SCRIPT_DIR/hooks/session-end.js"              "$HOME/.claude/hooks/"
-for f in hooks.json session-start.sh stop-profile-update.js stop-session-enforcement.js persona-rule.js briefing-runtime.js session-sync.js session-end.js; do
+for f in hooks.json session-start.sh stop-profile-update.js stop-session-enforcement.js stop-final-report.js persona-rule.js briefing-runtime.js session-sync.js session-end.js; do
   echo "hooks/$f" >> "$MANIFEST_TMP"
 done
 mkdir -p "$HOME/.claude/scripts"


### PR DESCRIPTION
Boss's completion summaries were free-form — sometimes tables, sometimes prose, sometimes nothing. This defines a **FINAL REPORT** that runs at the **very end of reasoning** (never as a mid-task progress update), plus the enforcement to make it reliable.

## Two halves — a prompt alone is advisory

**1. `boss.md § FINAL REPORT` defines WHAT**

| Situation | Table | Columns |
|---|---|---|
| Files/settings changed | 변경 대조 | 대상 / Before / After / 근거 |
| Multiple tasks done | 작업 요약 | 항목 / 결과 / 근거 |
| Verification ran | 검증 결과 | 항목 / 기대 / 실제 / 판정 |
| Commits/PRs produced | 산출물 | PR / 저장소 / 내용 / 상태 |
| Anything unresolved | 남은 것 | 항목 / 상태 / 다음 조치 |

Only tables whose situation occurred; never an empty table. **Before/After is mandatory** whenever existing files or settings were modified. Fires only on turns where state changed — pure Q&A ends normally.

**2. `hooks/stop-final-report.js` enforces it**

On Stop: work happened this turn + final message has no report → **block once** with the spec as the reason.

Judgment inputs come straight from the harness — no transcript parsing:
- the documented **`last_assistant_message`** Stop-hook field is the final text
- "work happened" = **workCounter delta** since the last acknowledged report, so a session-long counter doesn't nag on later chat-only turns

**Loop safety** (Stop blocks have no built-in circuit breaker): at most one block per `prompt_id` — the second Stop of the same turn acknowledges and lets the turn end even if the model ignored us — and the hook **fails open on any error**. Same `decision:'block'` + state-guard pattern as the existing `stop-session-enforcement.js`.

## Verified locally (installed via `install.sh`, tested against `~/.claude`, not the repo copy)

| case | result |
|---|---|
| no work (wc=0) | ✅ pass silently |
| work + no report | ✅ block, Korean reason |
| same prompt_id again | ✅ pass + ack (loop guard) |
| work + table / heading | ✅ pass + ack |
| ack'd then chat-only turn | ✅ pass |
| new work after ack | ✅ block |
| missing `last_assistant_message` / broken stdin | ✅ fail open |
| install | ✅ exit 0, Stop hooks 3→4, validate-hooks OK, 123 skills preserved |

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p