### PR TITLE
docs: hook count 8 -> 9 and document the final-report Stop hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "my-claude",
-  "description": "Dynamic orchestrator plugin — 32 curated agents, 139 curated skills, 8 hooks, and 3 MCP servers. Upstream sources linked via git submodules (everything-claude-code, oh-my-claudecode, gstack, superpowers)",
+  "description": "Dynamic orchestrator plugin — 32 curated agents, 139 curated skills, 9 hooks, and 3 MCP servers. Upstream sources linked via git submodules (everything-claude-code, oh-my-claudecode, gstack, superpowers)",
   "version": "0.55.0",
   "author": {
     "name": "sehoon787"

--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -1,7 +1,7 @@
 # my-claude AI Installation Guide
 
 You are an AI agent setting up a Claude Code multi-agent orchestration environment.
-The plugin bundles 32 curated agents, 139 curated skills, 54 rule files (9 rule sets), 8 hooks, 3 MCP servers, and 2 LSP servers.
+The plugin bundles 32 curated agents, 139 curated skills, 54 rule files (9 rule sets), 9 hooks, 3 MCP servers, and 2 LSP servers.
 `install.sh` additionally copies 2 named workflows to `~/.claude/workflows/` and installs the LSP binaries.
 Only 2-3 steps are needed.
 
@@ -96,7 +96,7 @@ This installs:
 - 139 skills (79 ECC + 27 gstack + 16 OMC + 13 Superpowers + 4 Core)
   Note: gstack skills are installed separately — run Step 1b (`install.sh`) for those.
 - 54 rule files across 9 rule sets
-- 8 behavioral hooks across 8 events (SessionStart, PreToolUse, PostToolUse, SubagentStop, TeammateIdle, TaskCompleted, Stop, UserPromptSubmit)
+- 9 behavioral hooks across 8 events (SessionStart, PreToolUse, PostToolUse, SubagentStop, TeammateIdle, TaskCompleted, Stop, UserPromptSubmit)
   - The SessionStart hook auto-creates a `.briefing/` vault per-project (with `INDEX.md`) on first session. This provides persistent project context, decision logs, and session summaries.
 - 3 MCP servers globally (Context7, Exa, grep.app) — available in all projects
 - 2 LSP servers declared in `.lsp.json` (typescript, python) — auto-started diagnostics and code navigation for agents
@@ -127,7 +127,7 @@ rm -rf /tmp/my-claude
 This installs everything in one step:
 - 32 agents (Boss + OMO + OMC + vendored)
 - 139 skills (ECC + gstack + OMC + Superpowers + Core)
-- 54 rule files (9 rule sets), 8 hooks
+- 54 rule files (9 rule sets), 9 hooks
 - 3 MCP servers (Context7, Exa, grep.app)
 - 2 named workflows in `~/.claude/workflows/` (code-review-fanout, upstream-audit) — usable from any project via the Workflow tool
 - 2 LSP server binaries (`typescript-language-server`, `pyright-langserver`) — installed non-fatally, a missing binary only disables that one server

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 
@@ -459,6 +459,8 @@ Run `/boss-briefing` during or at the end of a session to:
 - **Validate session notes**: Check that today's session has a proper summary
 
 The Stop hook checks whether `/boss-briefing` has run today. If not, it blocks session end with a reminder. The existing `stop-profile-update.js` continues to run as a fallback.
+
+A second Stop hook, `stop-final-report.js`, enforces Boss's FINAL REPORT: when a turn changed state (files edited, commits made, verification run) but the final message lacks the structured report tables defined in `boss.md § FINAL REPORT`, it blocks once with the spec as the reminder. It judges from the harness-provided `last_assistant_message` (no transcript parsing), blocks at most once per turn, and fails open on any error.
 
 ---
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -13,7 +13,7 @@
 ![Skills](https://img.shields.io/badge/skills-139-purple)
 ![Rules](https://img.shields.io/badge/rules-54-orange)
 ![MCP Servers](https://img.shields.io/badge/MCP-3-green)
-![Hooks](https://img.shields.io/badge/hooks-8-red)
+![Hooks](https://img.shields.io/badge/hooks-9-red)
 ![LSP Servers](https://img.shields.io/badge/LSP-2-008b8b)
 ![Workflows](https://img.shields.io/badge/workflows-2-blueviolet)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>my-claude — All-in-one agent harness for Claude Code</title>
-<meta name="description" content="All-in-one Claude Code multi-agent orchestration plugin. 32 curated agents, 139 curated skills, 54 rules, 3 MCP servers, 8 hooks, 2 LSP servers, 2 named workflows.">
+<meta name="description" content="All-in-one Claude Code multi-agent orchestration plugin. 32 curated agents, 139 curated skills, 54 rules, 3 MCP servers, 9 hooks, 2 LSP servers, 2 named workflows.">
 <meta property="og:title" content="my-claude — All-in-one agent harness for Claude Code">
 <meta property="og:description" content="Boss orchestrates 32 curated agents, 139 curated skills, 54 rules, 3 MCP servers. Dynamic runtime discovery. One plugin.">
 <meta property="og:type" content="website">
@@ -362,7 +362,7 @@ section{padding:80px 0}
       <div class="arch-layer"><h4 style="color:var(--accent)">P1/P2<span class="cnt"><span class="lang" data-en="Skill/Agent" data-ko="스킬/에이전트"></span></span></h4><p><span class="lang" data-en="Direct match" data-ko="직접 매칭"></span></p></div>
     </div>
     <div class="arch-conn"></div>
-    <div class="arch-layer"><h4><span class="lang" data-en="Behavioral Layer" data-ko="행동 규칙 레이어"></span><span class="cnt">54 rules &middot; 8 hooks</span></h4><p>Karpathy Guidelines &middot; ECC Rules &middot; PreToolUse / PostToolUse</p></div>
+    <div class="arch-layer"><h4><span class="lang" data-en="Behavioral Layer" data-ko="행동 규칙 레이어"></span><span class="cnt">54 rules &middot; 9 hooks</span></h4><p>Karpathy Guidelines &middot; ECC Rules &middot; PreToolUse / PostToolUse</p></div>
     <div class="arch-conn"></div>
     <div class="arch-layer"><h4><span class="lang" data-en="Specialist Agents" data-ko="전문 에이전트"></span><span class="cnt">32</span></h4><p>Boss 1 &middot; OMO 9 &middot; OMC 19 &middot; Vendored 3</p></div>
     <div class="arch-conn"></div>
@@ -448,7 +448,7 @@ section{padding:80px 0}
       </div>
     </details>
     <details>
-      <summary>MCP + Hooks <span class="cat-count">3 MCP &middot; 8 hooks</span></summary>
+      <summary>MCP + Hooks <span class="cat-count">3 MCP &middot; 9 hooks</span></summary>
       <div class="cat-body"><strong>MCP:</strong> Context7 (docs), Exa (web search), grep.app (GitHub code search)<br><strong>Hooks:</strong> 8 hook files across 8 events: SessionStart, PreToolUse, PostToolUse (&times;3), SubagentStop, TeammateIdle, TaskCompleted, Stop, UserPromptSubmit</div>
     </details>
     <details>


### PR DESCRIPTION
stop-final-report.js (#189) raised the hook count to 9, but the docs still said 8 in **13 places** — README badge, AI-INSTALL (×3), plugin.json description, the GitHub Pages site (×3), and all five translated READMEs.

Also added a short README paragraph documenting the new Stop hook next to the existing Stop-hook docs: what triggers it (state changed but no FINAL REPORT tables in the final message), how it judges (harness-provided `last_assistant_message`, no transcript parsing), and its safety properties (blocks at most once per turn, fails open).

Verification: zero `8 hooks` / `hooks-8` / `8 behavioral` matches remain; plugin.json still parses.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p