### PR TITLE
feat: add codeburn as a companion CLI, and stop wiping third-party hooks

### DIFF
--- a/AI-INSTALL.md
+++ b/AI-INSTALL.md
@@ -107,11 +107,11 @@ This installs:
 ## Step 1b: Manual install (if plugin unavailable)
 
 `install.sh` is the single source of truth for installation. It handles everything:
-agents, skills, rules, hooks, MCP servers, companion tools (omc, omo, ast-grep),
+agents, skills, rules, hooks, MCP servers, companion tools (omc, omo, ast-grep, comment-checker, codeburn),
 gstack, Anthropic skills, Karpathy guidelines, and manifest generation.
 
 Prerequisites: `bash` (Git Bash or WSL on Windows — this is a bash script, not
-PowerShell), `node`/`npm` (v20+), and `git`. `install.sh` checks for these and
+PowerShell), `node`/`npm` (v22.13+ — required by codeburn), and `git`. `install.sh` checks for these and
 exits with an error naming whichever is missing before doing anything else.
 
 ```bash
@@ -131,7 +131,7 @@ This installs everything in one step:
 - 3 MCP servers (Context7, Exa, grep.app)
 - 2 named workflows in `~/.claude/workflows/` (code-review-fanout, upstream-audit) — usable from any project via the Workflow tool
 - 2 LSP server binaries (`typescript-language-server`, `pyright-langserver`) — installed non-fatally, a missing binary only disables that one server
-- Companion tools: OMC CLI, omo CLI, ast-grep
+- Companion tools: OMC CLI, omo CLI, ast-grep, comment-checker, codeburn (budget-guard hooks opt-in via `--with-codeburn-guard`)
 - Anthropic Official Skills (pdf, docx)
 - Karpathy coding guidelines
 - gstack sprint-process harness (27 skills)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ A sprint-process harness by Garry Tan. my-claude installs 26 of its skills plus 
 
 Jesse Vincent's development-process skill library. my-claude installs 13 of its 14 skills — brainstorming, systematic debugging, TDD, plan writing and execution, and code-review etiquette. (`dispatching-parallel-agents` is excluded because Boss and Agent Teams already own that path.)
 
+### 8. [codeburn](https://github.com/getagentseal/codeburn)
+
+Local-first AI token and cost tracker. Reads the session files Claude Code already writes (`~/.claude/projects/**/*.jsonl`) and breaks spend down by model, project, and task — no proxy, no API key, nothing leaves the machine. Installed as a companion CLI (`codeburn`, pinned in `install.sh`); the budget-guard hooks are opt-in via `bash install.sh --with-codeburn-guard` because they add a PreToolUse hook on every tool call. Complements the OMC HUD: the HUD shows this session's context and quota, codeburn shows where money went across sessions.
+
 ---
 
 ## How Boss Works
@@ -265,7 +269,7 @@ Deterministic multi-agent workflows. `install.sh` copies them to `~/.claude/work
 | **LSP Servers** | 2 | typescript (`typescript-language-server`), python (`pyright-langserver`) |
 | **Named Workflows** | 2 | code-review-fanout, upstream-audit |
 | **Upstream submodules** | 4 | ecc, omc, gstack, superpowers |
-| **CLI Tools** | 3 | omc, omo, ast-grep |
+| **CLI Tools** | 5 | omc, omo, ast-grep, comment-checker, codeburn |
 
 Every agent, skill, and rule above is allowlisted in [`scripts/skill-allowlists.sh`](./scripts/skill-allowlists.sh) and tracked in the install manifest. Anthropic's official document skills (pdf, docx, …) are added separately via `claude plugin add anthropics/skills` and are deliberately not manifest-tracked.
 

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ for arg in "$@"; do
     --skip-gstack)     SKIP_GSTACK=1 ;;
     --skip-superpowers) SKIP_SUPERPOWERS=1 ;;
     --self-only)       SKIP_ECC=1; SKIP_OMC=1; SKIP_GSTACK=1; SKIP_SUPERPOWERS=1 ;;
+    --with-codeburn-guard) WITH_CODEBURN_GUARD=1 ;;
     -h|--help)
       cat <<'EOF'
 Usage:
@@ -590,7 +591,11 @@ else
   oh-my-opencode install --no-tui --claude=yes --openai=no --gemini=no --copilot=no 2>/dev/null || true
   echo "    omo installed"
 fi
-npm i -g @ast-grep/cli@0.42.0 @code-yeongyu/comment-checker@0.7.0 2>/dev/null || true
+npm i -g @ast-grep/cli@0.42.0 @code-yeongyu/comment-checker@0.7.0 codeburn@0.9.23 2>/dev/null || true
+# codeburn budget guard is opt-in: it adds a PreToolUse hook on every tool call.
+if [ "${WITH_CODEBURN_GUARD:-0}" = "1" ] && command -v codeburn >/dev/null 2>&1; then
+  codeburn guard install 2>/dev/null && echo "  codeburn guard hooks installed" || echo "  WARNING: codeburn guard install failed"
+fi
 
 # 5c-lsp. Language servers for the plugin's .lsp.json declaration (typescript + python).
 # Binaries must be on PATH (docs: plugins-reference → LSP servers); a missing binary
@@ -657,6 +662,7 @@ echo "  hooks:            $(find "$HOME/.claude/hooks"  -type f      2>/dev/null
 echo "  omc:              $(command -v omc            >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo "  omo:              $(command -v oh-my-opencode >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo "  ast-grep:         $(command -v ast-grep       >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
+echo "  codeburn:         $(command -v codeburn       >/dev/null 2>&1 && echo 'OK' || echo 'MISSING')"
 echo "  tmux:             $(command -v tmux >/dev/null 2>&1 && echo "OK ($(tmux -V))" || echo 'NOT INSTALLED (in-process mode)')"
 echo "  hud:              $(test -f "$HOME/.claude/hud/omc-hud.mjs" && echo 'OK' || echo 'MISSING')"
 TEAMMATE_MODE=$(node -e "try{const h=process.env.HOME||process.env.USERPROFILE;console.log(JSON.parse(require('fs').readFileSync(h+'/.claude/settings.json','utf8')).teammateMode||'auto')}catch(e){console.log('auto')}")

--- a/scripts/merge-hooks.js
+++ b/scripts/merge-hooks.js
@@ -1,6 +1,15 @@
 // Usage: node scripts/merge-hooks.js <hooks-json-path>
 // Merges hooks from hooks.json into ~/.claude/settings.json
 // Resolves ${CLAUDE_PLUGIN_ROOT}/{hooks,scripts} to ~/.claude/{hooks,scripts}
+//
+// Ownership rule: this script replaces ONLY the entries my-claude ships and
+// keeps everything else. Previously it assigned each event's array wholesale,
+// which silently deleted any third-party hook registered on an event we also
+// use (PreToolUse / SessionStart / Stop) — e.g. `codeburn guard install` was
+// wiped on every re-run of install.sh. An entry counts as ours when its
+// command references our hooks/ or scripts/ dir, or is one of the inline
+// `node -e` hooks we ship (all of which touch .briefing/ or emit
+// hookSpecificOutput). Anything else is foreign and is preserved verbatim.
 const fs = require('fs');
 const path = require('path');
 const home = process.env.HOME || process.env.USERPROFILE;
@@ -17,7 +26,7 @@ const settings = fs.existsSync(settingsPath)
   : {};
 
 const srcHooks = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf8')).hooks || {};
-settings.hooks = settings.hooks || {};
+const existing = (settings.hooks && typeof settings.hooks === 'object') ? settings.hooks : {};
 
 // Resolve ${CLAUDE_PLUGIN_ROOT}/<subdir> → ~/.claude/<subdir> (forward slashes)
 const hooksDir = path.join(home, '.claude', 'hooks').replace(/\\/g, '/');
@@ -29,9 +38,22 @@ rawHooks = rawHooks.replace(/\$HOME\/\.claude\/hooks/g, hooksDir);
 rawHooks = rawHooks.replace(/\$HOME\/\.claude\/scripts/g, scriptsDir);
 const resolvedHooks = JSON.parse(rawHooks);
 
-for (const [event, entries] of Object.entries(resolvedHooks)) {
-  settings.hooks[event] = entries;
+const OWNERSHIP_MARKERS = [hooksDir, scriptsDir, '.briefing', 'BOSS PROTOCOL', '.gstack/analytics', 'hookSpecificOutput'];
+const isOurs = (cmd) => typeof cmd === 'string' && OWNERSHIP_MARKERS.some((m) => cmd.includes(m));
+
+const merged = {};
+const events = new Set([...Object.keys(existing), ...Object.keys(resolvedHooks)]);
+let preserved = 0;
+for (const event of events) {
+  const foreignGroups = (Array.isArray(existing[event]) ? existing[event] : [])
+    .map((g) => ({ ...g, hooks: (Array.isArray(g.hooks) ? g.hooks : []).filter((h) => !isOurs(h && h.command)) }))
+    .filter((g) => g.hooks.length > 0);
+  preserved += foreignGroups.reduce((n, g) => n + g.hooks.length, 0);
+  const ours = Array.isArray(resolvedHooks[event]) ? resolvedHooks[event] : [];
+  const groups = [...ours, ...foreignGroups];
+  if (groups.length > 0) merged[event] = groups;
 }
+settings.hooks = merged;
 
 fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-console.log('  hooks merged into settings.json');
+console.log(`  hooks merged into settings.json (${preserved} third-party hook${preserved === 1 ? '' : 's'} preserved)`);

--- a/upstream/SOURCES.json
+++ b/upstream/SOURCES.json
@@ -26,8 +26,15 @@
     "repo": "https://github.com/garrytan/gstack",
     "path": "upstream/gstack",
     "method": "submodule + setup",
-    "supersedes": ["benchmark", "canary-watch", "safety-guard", "browser-qa",
-                   "verification-loop", "security-review", "design-system"],
+    "supersedes": [
+      "benchmark",
+      "canary-watch",
+      "safety-guard",
+      "browser-qa",
+      "verification-loop",
+      "security-review",
+      "design-system"
+    ],
     "branch": "main",
     "syncedSha": "initial",
     "syncedTag": null,
@@ -50,6 +57,30 @@
     "method": "submodule",
     "pinned_sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
     "pinned_date": "2026-08-31",
+    "license": "MIT"
+  },
+  "codeburn": {
+    "repo": "https://github.com/getagentseal/codeburn",
+    "method": "npm-cli",
+    "package": "codeburn",
+    "pinned_version": "0.9.23",
+    "note": "Local-first AI token/cost tracker; reads session files read-only, no proxy, no upload. Budget-guard hooks are opt-in (--with-codeburn-guard).",
+    "license": "MIT"
+  },
+  "ast-grep": {
+    "repo": "https://github.com/ast-grep/ast-grep",
+    "method": "npm-cli",
+    "package": "@ast-grep/cli",
+    "pinned_version": "0.42.0",
+    "note": "Structural code search/rewrite CLI used by agents",
+    "license": "MIT"
+  },
+  "comment-checker": {
+    "repo": "https://github.com/code-yeongyu/go-claude-code-comment-checker",
+    "method": "npm-cli",
+    "package": "@code-yeongyu/comment-checker",
+    "pinned_version": "0.7.0",
+    "note": "Comment quality checker companion CLI",
     "license": "MIT"
   }
 }


### PR DESCRIPTION
Adds [codeburn](https://github.com/getagentseal/codeburn) (MIT, 10.7k★) — a local-first token/cost tracker that reads the session files Claude Code already writes. No proxy, no API key, nothing leaves the machine.

## Why companion CLI, not upstream submodule

There are no skills or agents to vendor; it is an npm binary like `ast-grep`. A submodule would put a 1,855-commit app under the 3-day `scan-upstream-diff` gate for nothing. Provenance is kept anyway: **`upstream/SOURCES.json` (AI-BOM) now records it** with `method: npm-cli`, pinned version, and license.

That fixes a pre-existing gap too — `ast-grep` and `comment-checker` have shipped via `install.sh` for months without appearing in the ledger. Both are now registered.

## Not overlapping the HUD

| | OMC HUD | codeburn |
|---|---|---|
| scope | **this session**, live | **all sessions**, historical |
| shows | context %, model, agents/tasks, subscription quota % | $ / tokens by model · project · task |
| Codex | no | yes |

## Budget guard is opt-in

`bash install.sh --with-codeburn-guard` — it adds a PreToolUse hook on every tool call, so it is off by default. Its Stop hook never blocks (nudge only), so it cannot collide with `stop-final-report.js`.

## Prerequisite fix: `merge-hooks.js` was deleting third-party hooks

It assigned each event array wholesale, so **any** foreign hook on PreToolUse / SessionStart / Stop — exactly what codeburn registers — was wiped on every `install.sh` re-run. It now replaces only entries my-claude owns and preserves the rest.

| fixture case | result |
|---|---|
| 3 codeburn hooks | ✅ preserved |
| user `Notification` hook | ✅ preserved |
| stale my-claude hook (old path) | ✅ removed |
| duplicates after 2 runs | ✅ 0 (idempotent) |

Node requirement → 22.13+ (codeburn engines floor). Drift check passes (75 files).

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p