### PR TITLE
docs(pages): hero badge still said 8 hooks — bump to 9

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -239,7 +239,7 @@ section{padding:80px 0}
     <span class="badge"><em>139</em>&nbsp;skills</span>
     <span class="badge"><em>54</em>&nbsp;rules</span>
     <span class="badge"><em>3</em>&nbsp;MCP</span>
-    <span class="badge"><em>8</em>&nbsp;hooks</span>
+    <span class="badge"><em>9</em>&nbsp;hooks</span>
     <span class="badge"><em>2</em>&nbsp;LSP</span>
     <span class="badge"><em>2</em>&nbsp;workflows</span>
   </div>


### PR DESCRIPTION
#191 updated every `8 hooks` string, but the hero badge is marked up as `<em>8</em>&nbsp;hooks` and slipped through. Spotted on a live screenshot of the deployed site after the i18n/codeburn deploy.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p