### PR TITLE
docs(boss): keep the English README and agent prompt English-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ Boss closes every working turn — any turn that edited files, made commits/PRs,
 
 | Situation | Table | Columns |
 |-----------|-------|---------|
-| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
-| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
-| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
-| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
-| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+| Files/settings changed | Changes | Target / Before / After / Rationale |
+| Multiple tasks completed | Work summary | Item / Result / Evidence |
+| Verification was run | Verification | Item / Expected / Actual / Verdict |
+| Commits/PRs produced | Deliverables | PR / Repo / Content / Status |
+| Anything unresolved | Remaining | Item / Status / Next step |
 
 It fires only at the very end of reasoning — never as a mid-task progress update — and pure Q&A turns end normally without it. The spec lives in `boss.md § FINAL REPORT`; the `stop-final-report.js` Stop hook enforces it (see [Hooks](#-briefing-vault)).
 

--- a/agents/core/boss.md
+++ b/agents/core/boss.md
@@ -295,17 +295,17 @@ This section runs at the VERY END of your reasoning — after all delegation, ve
 
 | Situation | Table | Columns |
 |-----------|-------|---------|
-| Files/settings changed | 변경 대조 (Changes) | 대상 / Before / After / 근거 |
-| Multiple tasks completed | 작업 요약 (Work summary) | 항목 / 결과 / 근거 |
-| Verification was run | 검증 결과 (Verification) | 항목 / 기대 / 실제 / 판정 |
-| Commits/PRs produced | 산출물 (Deliverables) | PR / 저장소 / 내용 / 상태 |
-| Anything unresolved | 남은 것 (Remaining) | 항목 / 상태 / 다음 조치 |
+| Files/settings changed | Changes | Target / Before / After / Rationale |
+| Multiple tasks completed | Work summary | Item / Result / Evidence |
+| Verification was run | Verification | Item / Expected / Actual / Verdict |
+| Commits/PRs produced | Deliverables | PR / Repo / Content / Status |
+| Anything unresolved | Remaining | Item / Status / Next step |
 
 Rules:
 - Before/After tables are MANDATORY whenever you modified existing files or settings — the reader must see what changed without opening a diff.
-- Every 검증 결과 row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
-- 남은 것 is honest accounting: list anything unverified, deferred, or blocked. An empty "Remaining" claim with unresolved work is worse than a long one.
-- Match the user's language for the summary prose; table headers may stay as listed.
+- Every Verification row needs real evidence (actual command output, exit codes, counts) — never claim a pass you did not observe.
+- Remaining is honest accounting: list anything unverified, deferred, or blocked. An empty "Remaining" claim with unresolved work is worse than a long one.
+- Match the user's language for the prose AND the table names and headers alike — translate them; never leave English table headers in a non-English reply.
 
 Enforcement: the `stop-final-report.js` Stop hook checks the turn's final message and blocks once with a reminder if work happened but no report is present. Write the report on your own — the hook is the safety net, not the trigger.
 


### PR DESCRIPTION
The FINAL REPORT table shipped with **Korean table names and column headers inside the English README and the Boss agent definition**. English sources now use English names (Changes / Work summary / Verification / Deliverables / Remaining) and English columns.

The rule changes from "headers may stay as listed" to: *translate the table names and headers into the user's language alike* — so Korean users still get `변경 대조 / 대상 / Before / After / 근거` at reply time, and the translated READMEs (already localized) are unchanged.

Remaining Korean in the agent prompt is limited to the keyword→skill trigger line (e.g. "정기 감사" → `/cso`), which is functional routing for Korean input, not prose.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p