### PR TITLE
fix(ci): release when agent, hook, or installer files change regardless of commit type

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -42,6 +42,13 @@ jobs:
             echo "level=minor" >> $GITHUB_OUTPUT
           elif echo "$COMMITS" | grep -qiE "^(fix|perf|refactor)(\(.*\))?:"; then
             echo "level=patch" >> $GITHUB_OUTPUT
+          # Commit type alone is not enough: agent definitions, hooks, and the
+          # installer are shipped to users by install.sh, so a change there must
+          # release even when it was committed as docs:/chore:. Without this,
+          # boss.md edits labelled docs(boss) sat unreleased while releases/latest
+          # kept serving the old prompt.
+          elif [ "$LAST_TAG" != "v0.0.0" ] && git diff --name-only "${LAST_TAG}..HEAD" | grep -qE "^(agents/|hooks/|scripts/|install\.sh$|\.claude-plugin/)"; then
+            echo "level=patch" >> $GITHUB_OUTPUT
           else
             echo "level=none" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
auto-tag derived the bump level from commit-message types alone, so #197 — which rewrote the Boss agent prompt but was labelled `docs(boss)` — produced **no release**. `releases/latest` kept serving v0.56.0 with the old prompt, and the documented install routine (pinned to `releases/latest`) could not deliver the change to anyone.

`agents/`, `hooks/`, `scripts/`, `install.sh`, and `.claude-plugin/` are what `install.sh` ships; a change there is user-facing whatever the commit type says. The bump step now falls back to a **patch** release when the diff since the last tag touches any of those paths.

Merging this (a `fix:` commit) also releases v0.56.1 carrying the #197 prompt change.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p