### PR TITLE
fix(ci): don't count the plugin version bump as a shippable change

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -47,7 +47,12 @@ jobs:
           # release even when it was committed as docs:/chore:. Without this,
           # boss.md edits labelled docs(boss) sat unreleased while releases/latest
           # kept serving the old prompt.
-          elif [ "$LAST_TAG" != "v0.0.0" ] && git diff --name-only "${LAST_TAG}..HEAD" | grep -qE "^(agents/|hooks/|scripts/|install\.sh$|\.claude-plugin/)"; then
+          # .claude-plugin/plugin.json is excluded: the post-release "chore: bump
+          # plugin version" commit touches it, and counting that made every
+          # following docs/chore push release again (v0.56.2 was docs-only).
+          elif [ "$LAST_TAG" != "v0.0.0" ] && git diff --name-only "${LAST_TAG}..HEAD" \
+               | grep -v "^\.claude-plugin/plugin\.json$" \
+               | grep -qE "^(agents/|hooks/|scripts/|install\.sh$|\.claude-plugin/)"; then
             echo "level=patch" >> $GITHUB_OUTPUT
           else
             echo "level=none" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The post-release `chore: bump plugin version` commit edits `.claude-plugin/plugin.json`; the shipped-files fallback from #198 matched it, so every following push (even docs-only, e.g. v0.56.2) released again. This excludes that one file from the fallback — genuine `.claude-plugin/` changes still release.

Simulation against real ranges: `v0.56.1..ac43e03f` (docs + bump) → none (was patch); `v0.56.3..86afb025` (#204) and `v0.56.4..9ffa84f3` (#206) → patch.

https://claude.ai/code/session_01KKtnUQjdGp1TTjnyKHkj9p